### PR TITLE
ci: Add check in u-tests to prevent innecesary runs

### DIFF
--- a/.github/workflows/scala-ci.yml
+++ b/.github/workflows/scala-ci.yml
@@ -29,6 +29,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.SYSADMIN_PAT }}
 
   u-tests:
+    if: "contains(github.event.head_commit.message, 'ci:') || contains(github.event.head_commit.message, '(ci)')"
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:


### PR DESCRIPTION
If the commit contains ci: or ci scope ('(ci)') it will ignore the u-tests step