### PR TITLE
feat: reusable workflows v2 + pr-size-label

### DIFF
--- a/.github/actions/shared/pr-size-label/action.yml
+++ b/.github/actions/shared/pr-size-label/action.yml
@@ -1,0 +1,97 @@
+name: PR size label
+description: Etiqueta el PR con su tamaño (size/xs..xl) según líneas y archivos modificados
+
+inputs:
+  github-token:
+    description: GITHUB_TOKEN del repo que invoca
+    required: true
+  xs-max-size:
+    description: Máximo de líneas para size/xs
+    required: false
+    default: "10"
+  s-max-size:
+    description: Máximo de líneas para size/s
+    required: false
+    default: "100"
+  m-max-size:
+    description: Máximo de líneas para size/m
+    required: false
+    default: "500"
+  l-max-size:
+    description: Máximo de líneas para size/l (mayor → size/xl)
+    required: false
+    default: "1000"
+  files-xs-max-size:
+    description: Máximo de archivos para size/xs
+    required: false
+    default: "2"
+  files-s-max-size:
+    description: Máximo de archivos para size/s
+    required: false
+    default: "10"
+  files-m-max-size:
+    description: Máximo de archivos para size/m
+    required: false
+    default: "30"
+  files-l-max-size:
+    description: Máximo de archivos para size/l (mayor → size/xl)
+    required: false
+    default: "100"
+  fail-if-xl:
+    description: Si "true", el job falla cuando el PR es size/xl
+    required: false
+    default: "false"
+  ignore-file-deletions:
+    description: Si "true", ignora deleciones al calcular tamaño
+    required: false
+    default: "false"
+  files-to-ignore:
+    description: Lista (separada por '|') de globs de archivos a ignorar
+    required: false
+    default: "package-lock.json|yarn.lock|*.lock|build.sbt.lock"
+
+runs:
+  using: composite
+  steps:
+    - name: Skip on fork PRs
+      id: gate
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const pr = context.payload.pull_request;
+          if (!pr?.head?.ref) {
+            core.setOutput('skip', 'true');
+            console.log("PR size label: contexto sin 'pull_request' — se omite.");
+            return;
+          }
+          const headRepo = pr.head.repo;
+          const thisRepoFullName = `${context.repo.owner}/${context.repo.repo}`;
+          if (!headRepo || headRepo.fork || headRepo.full_name !== thisRepoFullName) {
+            core.setOutput('skip', 'true');
+            console.log(`PR size label: PR desde fork u otro repo (${headRepo?.full_name ?? 'desconocido'}) — se omite.`);
+            return;
+          }
+          core.setOutput('skip', 'false');
+
+    - name: Apply size label
+      if: steps.gate.outputs.skip != 'true'
+      uses: codelytv/pr-size-labeler@v1
+      with:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        xs_label: size/xs
+        s_label: size/s
+        m_label: size/m
+        l_label: size/l
+        xl_label: size/xl
+        xs_max_size: ${{ inputs.xs-max-size }}
+        s_max_size: ${{ inputs.s-max-size }}
+        m_max_size: ${{ inputs.m-max-size }}
+        l_max_size: ${{ inputs.l-max-size }}
+        files_xs_max_size: ${{ inputs.files-xs-max-size }}
+        files_s_max_size: ${{ inputs.files-s-max-size }}
+        files_m_max_size: ${{ inputs.files-m-max-size }}
+        files_l_max_size: ${{ inputs.files-l-max-size }}
+        fail_if_xl: ${{ inputs.fail-if-xl }}
+        ignore_file_deletions: ${{ inputs.ignore-file-deletions }}
+        files_to_ignore: ${{ inputs.files-to-ignore }}

--- a/.github/workflows/scala-api-ci.yml
+++ b/.github/workflows/scala-api-ci.yml
@@ -1,0 +1,75 @@
+name: Scala API · CI (reusable)
+
+# Reusable workflow v2 — invocar desde el repo cliente con:
+#
+#   jobs:
+#     ci:
+#       uses: BQN-UY/CI-CD/.github/workflows/scala-api-ci.yml@v2
+#       secrets: inherit
+
+on:
+  workflow_call:
+    inputs:
+      java-version:
+        description: Versión de Java para sbt
+        required: false
+        type: string
+        default: "21"
+
+jobs:
+  auto-label:
+    name: Auto-label PR
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      issues: write
+    steps:
+      - uses: BQN-UY/CI-CD/.github/actions/shared/auto-label@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  label-check:
+    name: Verificar label de PR
+    needs: auto-label
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: BQN-UY/CI-CD/.github/actions/shared/label-check@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  pr-size-label:
+    name: Etiquetar tamaño de PR
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: BQN-UY/CI-CD/.github/actions/shared/pr-size-label@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  lint-build:
+    name: Lint & Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0          # sbt-dynver necesita historial Git completo
+      - uses: BQN-UY/CI-CD/.github/actions/backend/scala/lint-build@v2
+        with:
+          java-version: ${{ inputs.java-version }}
+
+  security:
+    name: Security scan
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write    # requerido para subir SARIF al tab de Security
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0          # detect-secrets analiza historial completo
+      - uses: BQN-UY/CI-CD/.github/actions/shared/security-scan@v2

--- a/.github/workflows/scala-api-make-release.yml
+++ b/.github/workflows/scala-api-make-release.yml
@@ -1,0 +1,112 @@
+name: Scala API · Make Release (reusable)
+
+# Reusable workflow v2 — invocar desde el repo cliente con:
+#
+#   on:
+#     workflow_dispatch:
+#       inputs:
+#         installation:
+#           description: "Instalaciones destino (coma-separado, ej. install-1,install-2). Vacío = todas."
+#           required: false
+#           default: ""
+#   jobs:
+#     make-release:
+#       uses: BQN-UY/CI-CD/.github/workflows/scala-api-make-release.yml@v2
+#       secrets: inherit
+#       with:
+#         installation: ${{ inputs.installation }}
+
+on:
+  workflow_call:
+    inputs:
+      java-version:
+        description: Versión de Java para sbt
+        required: false
+        type: string
+        default: "21"
+      sistema:
+        description: Nombre del servicio (default = vars.SISTEMA o nombre del repo)
+        required: false
+        type: string
+        default: ""
+      installation:
+        description: Instalaciones destino (coma-separado). Vacío = todas.
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  release:
+    name: Tag + Nexus + GitHub Release + deploy production + back-merge
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref_name, 'release/') || startsWith(github.ref_name, 'hotfix/')
+    environment: production
+    permissions:
+      contents: write             # requerido para crear tags y hacer push de ramas
+      security-events: write      # requerido para subir SARIF al tab de Security
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: BQN-UY/CI-CD/.github/actions/backend/scala/lint-build@v2
+        with:
+          java-version: ${{ inputs.java-version }}
+
+      - uses: BQN-UY/CI-CD/.github/actions/shared/security-scan@v2
+
+      - name: Extraer versión desde nombre de rama
+        id: version
+        shell: bash
+        run: |
+          # Deriva la versión directamente del nombre de la rama para garantizar
+          # que el tag creado coincide con la versión indicada en la rama.
+          # Soporta release/vX.Y.Z y hotfix/vX.Y.Z-descripcion
+          VERSION=$(echo "${{ github.ref_name }}" | grep -oP '(?<=/)v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          if [ -z "$VERSION" ]; then
+            echo "Error: no se pudo extraer versión desde '${GITHUB_REF_NAME}'. Formato esperado: release/vX.Y.Z o hotfix/vX.Y.Z-desc" >&2
+            exit 1
+          fi
+          echo "tag=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Crear tag SemVer
+        uses: BQN-UY/CI-CD/.github/actions/shared/semver-tag@v2
+        with:
+          tag: ${{ steps.version.outputs.tag }}
+
+      - name: Publish release JAR → Nexus
+        shell: bash
+        run: sbt publish
+        env:
+          NEXUS_USER:     ${{ secrets.NEXUS_USER }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+          NEXUS_URL:      ${{ secrets.NEXUS_URL }}
+
+      - name: GitHub Release
+        uses: BQN-UY/CI-CD/.github/actions/shared/github-release@v2
+        with:
+          tag: ${{ steps.version.outputs.tag }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge release → main
+        uses: BQN-UY/CI-CD/.github/actions/shared/git-merge@v2
+        with:
+          source: ${{ github.ref_name }}
+          target: main
+
+      - name: Back-merge main → develop
+        uses: BQN-UY/CI-CD/.github/actions/shared/git-merge@v2
+        with:
+          source: main
+          target: develop
+
+      - name: Deploy to production
+        uses: BQN-UY/CI-CD/.github/actions/shared/jenkins-deploy-trigger@v2
+        with:
+          environment:  production
+          service-url:  ${{ secrets.JENKINS_DEPLOY_URL }}
+          token:        ${{ secrets.JENKINS_DEPLOY_PRODUCTION_TOKEN }}
+          sistema:      ${{ inputs.sistema != '' && inputs.sistema || (vars.SISTEMA || github.event.repository.name) }}
+          version:      ${{ steps.version.outputs.tag }}
+          installation: ${{ inputs.installation }}

--- a/.github/workflows/scala-api-publish-deploy.yml
+++ b/.github/workflows/scala-api-publish-deploy.yml
@@ -1,0 +1,70 @@
+name: Scala API · Publish & Deploy (reusable)
+
+# Reusable workflow v2 — invocar desde el repo cliente con:
+#
+#   on:
+#     push:
+#       branches: [develop, "release/**", "hotfix/**"]
+#   jobs:
+#     publish-and-deploy:
+#       uses: BQN-UY/CI-CD/.github/workflows/scala-api-publish-deploy.yml@v2
+#       secrets: inherit
+
+on:
+  workflow_call:
+    inputs:
+      java-version:
+        description: Versión de Java para sbt
+        required: false
+        type: string
+        default: "21"
+      sistema:
+        description: Nombre del servicio (default = vars.SISTEMA o nombre del repo)
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  publish:
+    name: Publish JAR snapshot → Nexus + deploy testing/staging
+    runs-on: ubuntu-latest
+    environment: ${{ startsWith(github.ref, 'refs/heads/hotfix/') && 'staging' || 'testing' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0          # sbt-dynver necesita historial Git completo
+
+      - uses: BQN-UY/CI-CD/.github/actions/backend/scala/lint-build@v2
+        with:
+          java-version: ${{ inputs.java-version }}
+
+      - name: Publish snapshot to Nexus
+        id: publish
+        shell: bash
+        run: |
+          sbt publish
+          echo "version=$(sbt -batch -error 'print dynver')" >> "$GITHUB_OUTPUT"
+        env:
+          NEXUS_USER:     ${{ secrets.NEXUS_USER }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+          NEXUS_URL:      ${{ secrets.NEXUS_URL }}
+
+      - name: Deploy to testing
+        if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release/')
+        uses: BQN-UY/CI-CD/.github/actions/shared/jenkins-deploy-trigger@v2
+        with:
+          environment: testing
+          service-url: ${{ secrets.JENKINS_DEPLOY_URL }}
+          token:       ${{ secrets.JENKINS_DEPLOY_TESTING_TOKEN }}
+          sistema:     ${{ inputs.sistema != '' && inputs.sistema || (vars.SISTEMA || github.event.repository.name) }}
+          version:     ${{ steps.publish.outputs.version }}
+
+      - name: Deploy to staging
+        if: startsWith(github.ref, 'refs/heads/hotfix/')
+        uses: BQN-UY/CI-CD/.github/actions/shared/jenkins-deploy-trigger@v2
+        with:
+          environment: staging
+          service-url: ${{ secrets.JENKINS_DEPLOY_URL }}
+          token:       ${{ secrets.JENKINS_DEPLOY_STAGING_TOKEN }}
+          sistema:     ${{ inputs.sistema != '' && inputs.sistema || (vars.SISTEMA || github.event.repository.name) }}
+          version:     ${{ steps.publish.outputs.version }}

--- a/.github/workflows/scala-api-start-hotfix.yml
+++ b/.github/workflows/scala-api-start-hotfix.yml
@@ -1,0 +1,60 @@
+name: Scala API · Start Hotfix (reusable)
+
+# Reusable workflow v2 — invocar desde el repo cliente con:
+#
+#   on:
+#     workflow_dispatch:
+#       inputs:
+#         description:
+#           description: Descripción corta del bug (ej. fix-null-parser)
+#           required: true
+#   jobs:
+#     start-hotfix:
+#       uses: BQN-UY/CI-CD/.github/workflows/scala-api-start-hotfix.yml@v2
+#       secrets: inherit
+#       with:
+#         description: ${{ inputs.description }}
+
+on:
+  workflow_call:
+    inputs:
+      description:
+        description: Descripción corta del bug (ej. fix-null-parser)
+        required: true
+        type: string
+
+jobs:
+  start-hotfix:
+    # main == último tag de release: make-release siempre mergea a main y crea
+    # el tag en ese mismo commit. Partir de main es partir del estado de producción.
+    name: Crear hotfix branch desde main
+    runs-on: ubuntu-latest
+    if: github.ref_name == 'main'
+    permissions:
+      contents: write             # requerido para crear y pushear la rama
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Calcular versión patch
+        id: semver
+        uses: BQN-UY/CI-CD/.github/actions/shared/semver-tag@v2
+        with:
+          bump: patch
+          dry-run: "true"
+
+      - name: Crear hotfix branch
+        shell: bash
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          DESCRIPTION=$(echo "${{ inputs.description }}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
+          if [ -z "$DESCRIPTION" ]; then
+            echo "Error: description quedó vacía tras sanitizar. Usar solo letras, números y guiones." >&2
+            exit 1
+          fi
+          BRANCH="hotfix/${{ steps.semver.outputs.tag }}-${DESCRIPTION}"
+          git checkout -b "$BRANCH"
+          git push origin "$BRANCH"

--- a/.github/workflows/scala-api-start-release.yml
+++ b/.github/workflows/scala-api-start-release.yml
@@ -1,0 +1,55 @@
+name: Scala API · Start Release (reusable)
+
+# Reusable workflow v2 — invocar desde el repo cliente con:
+#
+#   on:
+#     workflow_dispatch:
+#       inputs:
+#         bump:
+#           description: Tipo de bump de versión
+#           required: true
+#           default: minor
+#           type: choice
+#           options: [major, minor, patch]
+#   jobs:
+#     start-release:
+#       uses: BQN-UY/CI-CD/.github/workflows/scala-api-start-release.yml@v2
+#       secrets: inherit
+#       with:
+#         bump: ${{ inputs.bump }}
+
+on:
+  workflow_call:
+    inputs:
+      bump:
+        description: Tipo de bump de versión (major | minor | patch)
+        required: true
+        type: string
+
+jobs:
+  start-release:
+    name: Crear release branch
+    runs-on: ubuntu-latest
+    if: github.ref_name == 'develop'
+    permissions:
+      contents: write             # requerido para crear y pushear la rama
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: develop
+
+      - name: Calcular versión
+        id: semver
+        uses: BQN-UY/CI-CD/.github/actions/shared/semver-tag@v2
+        with:
+          bump: ${{ inputs.bump }}
+          dry-run: "true"         # Solo calcula, no crea el tag
+
+      - name: Crear release branch
+        shell: bash
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "release/${{ steps.semver.outputs.tag }}"
+          git push origin "release/${{ steps.semver.outputs.tag }}"

--- a/.github/workflows/setup-labels.yml
+++ b/.github/workflows/setup-labels.yml
@@ -44,13 +44,10 @@ jobs:
             "size/xl|d93f0b|>1000 líneas o >100 archivos"
           )
 
+          # --force crea o actualiza (color + descripción) en una sola llamada,
+          # evitando el problema de paginación al listar labels existentes.
           for entry in "${labels[@]}"; do
             IFS='|' read -r name color desc <<< "$entry"
-            if gh label list --limit 200 --json name --jq '.[].name' | grep -Fxq "$name"; then
-              echo "Updating label: $name"
-              gh label edit "$name" --color "$color" --description "$desc"
-            else
-              echo "Creating label: $name"
-              gh label create "$name" --color "$color" --description "$desc"
-            fi
+            echo "Syncing label: $name"
+            gh label create "$name" --color "$color" --description "$desc" --force
           done

--- a/.github/workflows/setup-labels.yml
+++ b/.github/workflows/setup-labels.yml
@@ -1,0 +1,56 @@
+name: Setup labels (reusable)
+
+# Reusable workflow v2 — agnóstico al stack. Crea/sincroniza las labels
+# estándar de BQN-UY (tipo + tamaño). Invocar manualmente desde el repo cliente:
+#
+#   on:
+#     workflow_dispatch:
+#   jobs:
+#     setup-labels:
+#       uses: BQN-UY/CI-CD/.github/workflows/setup-labels.yml@v2
+#       secrets: inherit
+
+on:
+  workflow_call:
+
+jobs:
+  sync-labels:
+    name: Sincronizar labels estándar
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Create or update labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Formato: nombre|color|descripción
+          labels=(
+            # Tipo (label-check exige exactamente una)
+            "feature|0e8a16|Nueva funcionalidad retrocompatible"
+            "fix|d93f0b|Corrección de bug"
+            "chore|fbca04|Mantenimiento: configuración, CI, tests, docs, refactor"
+            "update|1d76db|Actualización de dependencias (Dependabot / Scala Steward)"
+            "deploy-action|b60205|Requiere acción manual en infra antes/durante el deploy"
+            "breaking-change|b60205|Cambio incompatible — bump de major"
+            # Tamaño (informativas — asignadas por pr-size-label)
+            "size/xs|c2e0c6|≤10 líneas y ≤2 archivos"
+            "size/s|7ed321|≤100 líneas y ≤10 archivos"
+            "size/m|fbca04|≤500 líneas y ≤30 archivos"
+            "size/l|f2a93b|≤1000 líneas y ≤100 archivos"
+            "size/xl|d93f0b|>1000 líneas o >100 archivos"
+          )
+
+          for entry in "${labels[@]}"; do
+            IFS='|' read -r name color desc <<< "$entry"
+            if gh label list --limit 200 --json name --jq '.[].name' | grep -Fxq "$name"; then
+              echo "Updating label: $name"
+              gh label edit "$name" --color "$color" --description "$desc"
+            else
+              echo "Creating label: $name"
+              gh label create "$name" --color "$color" --description "$desc"
+            fi
+          done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # BQN-UY/CI-CD — Contexto para AI
 
 Repositorio centralizado de CI/CD de la organización BQN-UY.
-Contiene las composite actions reutilizables (v2) y los reusable workflows heredados (v1).
+Contiene composite actions reutilizables (v2), reusable workflows v2 y los reusable workflows heredados (v1).
 
 ## Estructura del repo
 
@@ -11,19 +11,25 @@ Contiene las composite actions reutilizables (v2) y los reusable workflows hered
 │   ├── shared/       ← lógica agnóstica de stack (jenkins-deploy-trigger, semver-tag, etc.)
 │   ├── frontend/     ← acciones por stack frontend (html-js, vaadin, flutter)
 │   └── backend/      ← acciones por stack backend (scala, python, node)
-└── workflows/        ← reusable workflows v1  — NO MODIFICAR (legacy)
+└── workflows/        ← convive v1 (legacy) y v2 (reusable workflows)
+    ├── <stack>-<tipo>-<workflow>.yml  ← v2  (ej. scala-api-ci.yml) — MODIFICAR AQUÍ
+    ├── setup-labels.yml               ← v2 agnóstico al stack
+    └── (resto)                        ← v1 legacy — NO MODIFICAR
 
-templates/            ← workflows listos para copiar en repos de proyecto
+templates/            ← callers cortos listos para copiar en repos de proyecto
 docs/                 ← documentación de referencia v2
 ```
 
+> GitHub no soporta subcarpetas en `.github/workflows/` — la taxonomía stack/tipo se expresa en el nombre del archivo (`<stack>-<tipo>-<workflow>.yml`).
+
 ## Reglas
 
-- Modificar normalmente solo `.github/actions/`, `templates/` y `docs/`
+- Modificar normalmente `.github/actions/`, `.github/workflows/<stack>-*.yml`, `templates/` y `docs/`
 - Excepciones permitidas en raíz y `.github/`: `CLAUDE.md`, `.github/copilot-instructions.md` y archivos de configuración del repo
-- NUNCA modificar `.github/workflows/` — son workflows v1 legacy, no se migran
-- Los workflows de cada proyecto NO viven aquí — viven en el repo del proyecto
+- NUNCA modificar los workflows v1 legacy en `.github/workflows/` (los que no tienen prefijo `<stack>-`): `merge-update.yml`, `release-drafter.yml`, `remove-old-artifacts.yml`, `scala-ci.yml`, `scala-deploy-jar.yml`, `scala-deploy-web.yml`, `scala-make-release-jar.yml`, `scala-make-release-lib.yml`, `scala-make-release-web.yml`, `scala-publish-snapshot-lib.yml`, `start-hotfix.yml`
+- Los workflows ejecutables de cada proyecto NO viven aquí — viven en el repo del proyecto y son callers cortos al reusable workflow correspondiente
 - Toda nueva action v2 va en `.github/actions/<capa>/<stack>/<nombre>/action.yml`
+- Todo nuevo reusable workflow v2 va en `.github/workflows/<stack>-<tipo>-<workflow>.yml` con `on: workflow_call`
 
 ## Ambientes válidos (`shared/jenkins-deploy-trigger`)
 
@@ -42,7 +48,14 @@ docs/                 ← documentación de referencia v2
 
 1. Decidir capa: ¿`shared/`, `frontend/<stack>/` o `backend/<stack>/`?
 2. Crear `action.yml` en la carpeta correspondiente
-3. Agregar el template de workflow en `templates/<stack>/`
+3. Cablearla dentro del reusable workflow del stack/tipo correspondiente (`.github/workflows/<stack>-<tipo>-*.yml`)
+4. Documentar en `docs/migration-v2.md`
+
+## Cómo agregar un reusable workflow v2 para un nuevo stack/tipo
+
+1. Crear `.github/workflows/<stack>-<tipo>-<workflow>.yml` con `on: workflow_call` (ej. `scala-lib-ci.yml`)
+2. Componerlo con las composite actions correspondientes
+3. Crear `templates/<stack>-<tipo>/` con callers cortos (uno por workflow)
 4. Documentar en `docs/migration-v2.md`
 
 ## Referencia

--- a/docs/migration-v2.md
+++ b/docs/migration-v2.md
@@ -144,6 +144,54 @@ El path del `uses:` siempre sigue el mismo patrón:
 
 ---
 
+## 2.bis Reusable workflows (`.github/workflows/<stack>-<tipo>-*.yml`)
+
+A partir de v2, además de las composite actions, hay **reusable workflows** que componen las actions y exponen un `on: workflow_call`. Esto permite que los repos cliente solo declaren un caller corto y se mantengan sincronizados automáticamente con el tag `@v2`.
+
+### Convenciones
+
+- Subcarpetas no soportadas en `.github/workflows/` → la taxonomía va en el nombre: `<stack>-<tipo>-<workflow>.yml`
+- Los reusable workflows siempre tienen `on: workflow_call`
+- Los `secrets` se pasan con `secrets: inherit` desde el caller (requiere que los nombres coincidan con los documentados en §6)
+- Las labels (tipo + tamaño) y otros workflows agnósticos usan nombre sin prefijo de stack: `setup-labels.yml`
+
+### Catálogo actual
+
+| Reusable workflow | Tipo de proyecto | Trigger del caller |
+|---|---|---|
+| `scala-api-ci.yml` | API Scala | `pull_request` + `push` release/hotfix |
+| `scala-api-publish-deploy.yml` | API Scala | `push` develop / release / hotfix |
+| `scala-api-make-release.yml` | API Scala | `workflow_dispatch` |
+| `scala-api-start-release.yml` | API Scala | `workflow_dispatch` |
+| `scala-api-start-hotfix.yml` | API Scala | `workflow_dispatch` |
+| `setup-labels.yml` | Cualquiera | `workflow_dispatch` |
+
+### Caller mínimo
+
+```yaml
+# .github/workflows/ci.yml en el repo del proyecto
+name: CI
+on:
+  pull_request:
+    branches: [develop, "release/**", "hotfix/**"]
+  push:
+    branches: ["release/**", "hotfix/**"]
+jobs:
+  ci:
+    uses: BQN-UY/CI-CD/.github/workflows/scala-api-ci.yml@v2
+    secrets: inherit
+```
+
+Los templates en `templates/<stack>-<tipo>/` ya contienen los callers listos para copiar.
+
+### Cómo agregar un nuevo stack/tipo (ej. `scala-lib`, `vaadin-war`, `python-api`)
+
+1. Crear `.github/workflows/<stack>-<tipo>-<workflow>.yml` con `on: workflow_call` componiendo las composite actions correspondientes
+2. Crear `templates/<stack>-<tipo>/` con los callers cortos
+3. Documentar en este archivo
+
+---
+
 ## 3. Actions compartidas (`shared/`)
 
 Las actions de `shared/` no contienen lógica de stack. Se usan igual desde cualquier tipo
@@ -215,7 +263,43 @@ label-check:
 
 ---
 
-### 3.3 `shared/security-scan`
+### 3.3 `shared/pr-size-label`
+
+Etiqueta el PR con su tamaño (`size/xs`, `size/s`, `size/m`, `size/l`, `size/xl`) según líneas y archivos modificados.
+Envuelve [`codelytv/pr-size-labeler`](https://github.com/CodelyTV/pr-size-labeler) con thresholds por defecto.
+
+| Tamaño | Líneas | Archivos |
+|---|---|---|
+| `size/xs` | ≤10 | ≤2 |
+| `size/s`  | ≤100 | ≤10 |
+| `size/m`  | ≤500 | ≤30 |
+| `size/l`  | ≤1000 | ≤100 |
+| `size/xl` | >1000 | >100 |
+
+Cualquier umbral es ajustable vía inputs (`xs-max-size`, `files-xs-max-size`, etc.).
+Por defecto ignora lockfiles (`package-lock.json`, `yarn.lock`, `*.lock`, `build.sbt.lock`).
+
+Requiere `permissions: pull-requests: write` en el job que la invoca.
+Se omite automáticamente en PRs desde forks (donde el token viene con permisos read-only).
+
+```yaml
+pr-size-label:
+  name: Etiquetar tamaño de PR
+  runs-on: ubuntu-latest
+  if: github.event_name == 'pull_request'
+  permissions:
+    pull-requests: write
+  steps:
+    - uses: BQN-UY/CI-CD/.github/actions/shared/pr-size-label@v2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+> Las labels `size/*` son informativas — `label-check` no las cuenta como label de tipo.
+
+---
+
+### 3.4 `shared/security-scan`
 
 Corre **OpenGrep** (SAST) y **BetterLeaks** (secrets scanning) sobre el código.
 Si encuentra algo, el CI falla y el PR no puede mergearse.
@@ -227,7 +311,7 @@ No requiere inputs — opera sobre el checkout actual. Para que el upload de SAR
 
 ---
 
-### 3.4 `shared/semver-tag`
+### 3.5 `shared/semver-tag`
 
 Crea un tag SemVer 2.0 anotado (no firmado con GPG). Soporta dos modos:
 
@@ -258,7 +342,7 @@ Si se requieren tags firmados con GPG, el manejo de claves y la firma deben impl
 
 ---
 
-### 3.5 `shared/git-merge`
+### 3.6 `shared/git-merge`
 
 Realiza un back-merge automático sin conflictos. Al no existir archivos de versión
 (no hay `version.sbt` ni equivalente), este paso siempre es limpio.
@@ -272,7 +356,7 @@ Realiza un back-merge automático sin conflictos. Al no existir archivos de vers
 
 ---
 
-### 3.6 `shared/github-release`
+### 3.7 `shared/github-release`
 
 Crea un GitHub Release con release notes autogeneradas a partir de los PRs incluidos
 y sus labels. Usa `softprops/action-gh-release@v2`.
@@ -285,7 +369,7 @@ y sus labels. Usa `softprops/action-gh-release@v2`.
 
 ---
 
-### 3.7 `shared/jenkins-deploy-trigger`
+### 3.8 `shared/jenkins-deploy-trigger`
 
 Dispara el deploy vía [Generic Webhook Trigger (GWT)](https://plugins.jenkins.io/generic-webhook-trigger/)
 de Jenkins. El token se envía como query param `?token=` — GWT lo usa para rutear

--- a/templates/scala-api/CLAUDE.md
+++ b/templates/scala-api/CLAUDE.md
@@ -1,7 +1,14 @@
 # CI/CD v2 — Contexto para AI
 
-Este proyecto usa CI/CD v2 de BQN-UY. Las actions reutilizables viven en
-`BQN-UY/CI-CD`. Los workflows de este proyecto viven en `.github/workflows/`.
+Este proyecto usa CI/CD v2 de BQN-UY. La lógica de CI/CD vive en `BQN-UY/CI-CD`
+como **reusable workflows** (`.github/workflows/scala-api-*.yml`) que internamente
+componen las composite actions del repo. Los workflows de este proyecto son
+**callers cortos** que apuntan al reusable workflow correspondiente con `@v2`.
+
+Esto significa que cualquier cambio en la lógica de CI/CD se hace una sola vez
+en `BQN-UY/CI-CD` y se propaga automáticamente a todos los proyectos que pinean
+`@v2`. Los archivos `.github/workflows/*.yml` de este repo solo cambian cuando
+hay que ajustar inputs o triggers específicos del proyecto.
 
 ## Branching model
 
@@ -67,6 +74,9 @@ Este proyecto usa CI/CD v2 de BQN-UY. Las actions reutilizables viven en
 | `start-release.yml` | manual (workflow_dispatch) | crea `release/vX.Y.Z` desde develop |
 | `make-release.yml` | manual (workflow_dispatch) | tag + Nexus release + GitHub Release + deploy production + back-merge |
 | `start-hotfix.yml` | manual (workflow_dispatch) | crea `hotfix/vX.Y.Z-desc` desde main |
+| `setup-labels.yml` | manual (workflow_dispatch) | crea/sincroniza las labels estándar (tipo + `size/*`) — correr al inicializar el repo |
+
+> Las labels `size/xs..xl` son informativas y las asigna automáticamente `pr-size-label` en cada PR según líneas y archivos modificados. No reemplazan al label de tipo — `label-check` sigue exigiendo exactamente una de `feature` / `fix` / `chore` / `update` / `deploy-action` / `breaking-change`.
 
 ## Secrets y variables requeridos
 

--- a/templates/scala-api/ci.yml
+++ b/templates/scala-api/ci.yml
@@ -7,46 +7,8 @@ on:
     branches: ["release/**", "hotfix/**"]
 
 jobs:
-  auto-label:
-    name: Auto-label PR
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    permissions:
-      issues: write
-    steps:
-      - uses: BQN-UY/CI-CD/.github/actions/shared/auto-label@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-  label-check:
-    name: Verificar label de PR
-    needs: auto-label
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    permissions:
-      pull-requests: read
-    steps:
-      - uses: actions/checkout@v4
-      - uses: BQN-UY/CI-CD/.github/actions/shared/label-check@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-  lint-build:
-    name: Lint & Build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0          # sbt-dynver necesita historial Git completo
-      - uses: BQN-UY/CI-CD/.github/actions/backend/scala/lint-build@v2
-
-  security:
-    name: Security scan
-    runs-on: ubuntu-latest
-    permissions:
-      security-events: write    # requerido para subir SARIF al tab de Security
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0          # detect-secrets analiza historial completo
-      - uses: BQN-UY/CI-CD/.github/actions/shared/security-scan@v2
+  ci:
+    uses: BQN-UY/CI-CD/.github/workflows/scala-api-ci.yml@v2
+    secrets: inherit
+    # with:
+    #   java-version: "21"   # default; override solo si el proyecto usa otra versión

--- a/templates/scala-api/make-release.yml
+++ b/templates/scala-api/make-release.yml
@@ -12,75 +12,8 @@ on:
         default: ""
 
 jobs:
-  release:
-    name: Tag + Nexus + GitHub Release + deploy production + back-merge
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref_name, 'release/') || startsWith(github.ref_name, 'hotfix/')
-    environment: production
-    permissions:
-      contents: write             # requerido para crear tags y hacer push de ramas
-      security-events: write      # requerido para subir SARIF al tab de Security
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: BQN-UY/CI-CD/.github/actions/backend/scala/lint-build@v2
-
-      - uses: BQN-UY/CI-CD/.github/actions/shared/security-scan@v2
-
-      - name: Extraer versión desde nombre de rama
-        id: version
-        shell: bash
-        run: |
-          # Deriva la versión directamente del nombre de la rama para garantizar
-          # que el tag creado coincide con la versión indicada en la rama.
-          # Soporta release/vX.Y.Z y hotfix/vX.Y.Z-descripcion
-          VERSION=$(echo "${{ github.ref_name }}" | grep -oP '(?<=/)v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-          if [ -z "$VERSION" ]; then
-            echo "Error: no se pudo extraer versión desde '${GITHUB_REF_NAME}'. Formato esperado: release/vX.Y.Z o hotfix/vX.Y.Z-desc" >&2
-            exit 1
-          fi
-          echo "tag=$VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Crear tag SemVer
-        uses: BQN-UY/CI-CD/.github/actions/shared/semver-tag@v2
-        with:
-          tag: ${{ steps.version.outputs.tag }}
-
-      - name: Publish release JAR → Nexus
-        shell: bash
-        run: sbt publish
-        env:
-          NEXUS_USER:     ${{ secrets.NEXUS_USER }}
-          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-          NEXUS_URL:      ${{ secrets.NEXUS_URL }}
-
-      - name: GitHub Release
-        uses: BQN-UY/CI-CD/.github/actions/shared/github-release@v2
-        with:
-          tag: ${{ steps.version.outputs.tag }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Merge release → main
-        uses: BQN-UY/CI-CD/.github/actions/shared/git-merge@v2
-        with:
-          source: ${{ github.ref_name }}
-          target: main
-
-      - name: Back-merge main → develop
-        uses: BQN-UY/CI-CD/.github/actions/shared/git-merge@v2
-        with:
-          source: main
-          target: develop
-
-      - name: Deploy to production
-        uses: BQN-UY/CI-CD/.github/actions/shared/jenkins-deploy-trigger@v2
-        with:
-          environment:  production
-          service-url:  ${{ secrets.JENKINS_DEPLOY_URL }}
-          token:        ${{ secrets.JENKINS_DEPLOY_PRODUCTION_TOKEN }}
-          sistema:      ${{ vars.SISTEMA || github.event.repository.name }}
-          version:      ${{ steps.version.outputs.tag }}
-          installation: ${{ inputs.installation }}
+  make-release:
+    uses: BQN-UY/CI-CD/.github/workflows/scala-api-make-release.yml@v2
+    secrets: inherit
+    with:
+      installation: ${{ inputs.installation }}

--- a/templates/scala-api/publish-and-deploy.yml
+++ b/templates/scala-api/publish-and-deploy.yml
@@ -5,44 +5,9 @@ on:
     branches: [develop, "hotfix/**", "release/**"]
 
 jobs:
-  publish:
-    name: Publish JAR snapshot → Nexus + deploy testing/staging
-    runs-on: ubuntu-latest
-    environment: ${{ startsWith(github.ref, 'refs/heads/hotfix/') && 'staging' || 'testing' }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0          # sbt-dynver necesita historial Git completo
-
-      - uses: BQN-UY/CI-CD/.github/actions/backend/scala/lint-build@v2
-
-      - name: Publish snapshot to Nexus
-        id: publish
-        shell: bash
-        run: |
-          sbt publish
-          echo "version=$(sbt -batch -error 'print dynver')" >> "$GITHUB_OUTPUT"
-        env:
-          NEXUS_USER:     ${{ secrets.NEXUS_USER }}
-          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-          NEXUS_URL:      ${{ secrets.NEXUS_URL }}
-
-      - name: Deploy to testing
-        if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release/')
-        uses: BQN-UY/CI-CD/.github/actions/shared/jenkins-deploy-trigger@v2
-        with:
-          environment: testing
-          service-url: ${{ secrets.JENKINS_DEPLOY_URL }}
-          token:       ${{ secrets.JENKINS_DEPLOY_TESTING_TOKEN }}
-          sistema:     ${{ vars.SISTEMA || github.event.repository.name }}
-          version:     ${{ steps.publish.outputs.version }}
-
-      - name: Deploy to staging
-        if: startsWith(github.ref, 'refs/heads/hotfix/')
-        uses: BQN-UY/CI-CD/.github/actions/shared/jenkins-deploy-trigger@v2
-        with:
-          environment: staging
-          service-url: ${{ secrets.JENKINS_DEPLOY_URL }}
-          token:       ${{ secrets.JENKINS_DEPLOY_STAGING_TOKEN }}
-          sistema:     ${{ vars.SISTEMA || github.event.repository.name }}
-          version:     ${{ steps.publish.outputs.version }}
+  publish-and-deploy:
+    uses: BQN-UY/CI-CD/.github/workflows/scala-api-publish-deploy.yml@v2
+    secrets: inherit
+    # with:
+    #   java-version: "21"
+    #   sistema: "mi-servicio"   # default = vars.SISTEMA o nombre del repo

--- a/templates/scala-api/setup-labels.yml
+++ b/templates/scala-api/setup-labels.yml
@@ -1,0 +1,12 @@
+name: Setup labels
+
+# Crea/sincroniza las labels estándar de BQN-UY en este repo.
+# Correr una vez al inicializar el repo (o cuando se agreguen labels nuevas).
+
+on:
+  workflow_dispatch:
+
+jobs:
+  setup-labels:
+    uses: BQN-UY/CI-CD/.github/workflows/setup-labels.yml@v2
+    secrets: inherit

--- a/templates/scala-api/start-hotfix.yml
+++ b/templates/scala-api/start-hotfix.yml
@@ -9,36 +9,7 @@ on:
 
 jobs:
   start-hotfix:
-    # main == último tag de release: make-release siempre mergea a main y crea
-    # el tag en ese mismo commit. Partir de main es partir del estado de producción.
-    name: Crear hotfix branch desde main
-    runs-on: ubuntu-latest
-    if: github.ref_name == 'main'
-    permissions:
-      contents: write             # requerido para crear y pushear la rama
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: main
-
-      - name: Calcular versión patch
-        id: semver
-        uses: BQN-UY/CI-CD/.github/actions/shared/semver-tag@v2
-        with:
-          bump: patch
-          dry-run: "true"
-
-      - name: Crear hotfix branch
-        shell: bash
-        run: |
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          DESCRIPTION=$(echo "${{ inputs.description }}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
-          if [ -z "$DESCRIPTION" ]; then
-            echo "Error: description quedó vacía tras sanitizar. Usar solo letras, números y guiones." >&2
-            exit 1
-          fi
-          BRANCH="hotfix/${{ steps.semver.outputs.tag }}-${DESCRIPTION}"
-          git checkout -b "$BRANCH"
-          git push origin "$BRANCH"
+    uses: BQN-UY/CI-CD/.github/workflows/scala-api-start-hotfix.yml@v2
+    secrets: inherit
+    with:
+      description: ${{ inputs.description }}

--- a/templates/scala-api/start-release.yml
+++ b/templates/scala-api/start-release.yml
@@ -12,28 +12,7 @@ on:
 
 jobs:
   start-release:
-    name: Crear release branch
-    runs-on: ubuntu-latest
-    if: github.ref_name == 'develop'
-    permissions:
-      contents: write             # requerido para crear y pushear la rama
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: develop
-
-      - name: Calcular versión
-        id: semver
-        uses: BQN-UY/CI-CD/.github/actions/shared/semver-tag@v2
-        with:
-          bump: ${{ inputs.bump }}
-          dry-run: "true"         # Solo calcula, no crea el tag
-
-      - name: Crear release branch
-        shell: bash
-        run: |
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b "release/${{ steps.semver.outputs.tag }}"
-          git push origin "release/${{ steps.semver.outputs.tag }}"
+    uses: BQN-UY/CI-CD/.github/workflows/scala-api-start-release.yml@v2
+    secrets: inherit
+    with:
+      bump: ${{ inputs.bump }}


### PR DESCRIPTION
## Summary

- **Reusable workflows v2**: migra la lógica de CI/CD de `templates/scala-api/*.yml` (copia+paste en cada repo cliente) a reusable workflows `.github/workflows/scala-api-*.yml` que componen las composite actions existentes. Los templates ahora son callers cortos (~10 líneas) que apuntan a `@v2`. Cualquier cambio en `BQN-UY/CI-CD` se propaga automáticamente a todos los proyectos que pinean `@v2`.
- **`shared/pr-size-label`**: nueva composite action que envuelve `codelytv/pr-size-labeler@v1` con thresholds estándar y labels `size/xs..xl`.
- **`setup-labels.yml`**: reusable workflow agnóstico al stack que crea/sincroniza las labels estándar (tipo + `size/*`) vía `gh label`. Correr una vez por repo al inicializar.

### Archivos nuevos

- `.github/actions/shared/pr-size-label/action.yml`
- `.github/workflows/scala-api-{ci,publish-deploy,make-release,start-release,start-hotfix}.yml`
- `.github/workflows/setup-labels.yml`
- `templates/scala-api/setup-labels.yml`

### Convención de nombres

GitHub no soporta subcarpetas en `.github/workflows/`. La taxonomía stack/tipo va en el nombre: `<stack>-<tipo>-<workflow>.yml` (ej. `scala-api-ci.yml`, a futuro `scala-lib-ci.yml`, `vaadin-war-ci.yml`). Los workflows agnósticos al stack no llevan prefijo (ej. `setup-labels.yml`).

### Docs actualizados

- `CLAUDE.md` (raíz): nueva regla distinguiendo v1 legacy vs v2 reusable en `.github/workflows/`
- `docs/migration-v2.md`: nueva sección §2.bis con catálogo de reusable workflows y §3.3 para `pr-size-label`
- `templates/scala-api/CLAUDE.md`: explicación del modelo caller→reusable

## Test plan

- [ ] Revisar que los reusable workflows compilen (GitHub valida sintaxis al mergear)
- [ ] Tras el merge, retagear `v2` apuntando a este commit
- [ ] En un repo cliente de prueba, reemplazar sus workflows por los callers del template y correr un PR de ejemplo
- [ ] Verificar que `setup-labels.yml` crea las 11 labels (6 tipo + 5 size) correctamente
- [ ] Verificar que `pr-size-label` etiqueta PRs con `size/xs..xl` según líneas/archivos
- [ ] Verificar deploy testing/staging en un push a develop/hotfix del repo de prueba
- [ ] Verificar `make-release` end-to-end con un release ficticio

## Próximos pasos (fuera de este PR)

- Replicar el patrón para `scala-lib-*` (resuelve el pendiente de v2 para libs)
- Replicar para stacks frontend (`vaadin-war-*`, `flutter-mobile-*`)
- En cada repo cliente existente: migrar sus workflows a los callers cortos del template