### PR TITLE
fix: permisos auto-label y pin de sbt 1.11.6

### DIFF
--- a/.github/actions/backend/scala/lint-build/action.yml
+++ b/.github/actions/backend/scala/lint-build/action.yml
@@ -18,6 +18,8 @@ runs:
 
     - name: Setup sbt
       uses: sbt/setup-sbt@v1
+      with:
+        sbt-runner-version: "1.11.6"   # 1.12.8 (default) tiene release roto upstream — pinear hasta que se resuelva
 
     - name: Format check (scalafmt)
       shell: bash

--- a/.github/workflows/scala-api-ci.yml
+++ b/.github/workflows/scala-api-ci.yml
@@ -23,6 +23,7 @@ jobs:
     if: github.event_name == 'pull_request'
     permissions:
       issues: write
+      pull-requests: write
     steps:
       - uses: BQN-UY/CI-CD/.github/actions/shared/auto-label@v2
         with:


### PR DESCRIPTION
## Summary
- `scala-api-ci.yml`: agregar `pull-requests: write` al job `auto-label` (faltaba — producía 403 al listar labels del PR).
- `backend/scala/lint-build`: pinear `sbt-runner-version: 1.11.6` (default 1.12.8 distribuye un zip vacío upstream).

Detectado al validar la migración v2 en BQN-UY/acp-api#6.

## Test plan
- [ ] Mover tag `v2` a este commit y re-correr el CI de acp-api#6
- [ ] Verificar que `auto-label`, `label-check` y `lint-build` pasan