### PR TITLE
fix: permisos contents:read y env Nexus en scala-api-ci

### DIFF
--- a/.github/workflows/scala-api-ci.yml
+++ b/.github/workflows/scala-api-ci.yml
@@ -35,6 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     permissions:
+      contents: read
       pull-requests: read
     steps:
       - uses: actions/checkout@v4
@@ -56,6 +57,10 @@ jobs:
   lint-build:
     name: Lint & Build
     runs-on: ubuntu-latest
+    env:
+      TZ: America/Montevideo
+      NEXUS_USER: ${{ secrets.NEXUS_USER }}
+      NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -68,6 +73,7 @@ jobs:
     name: Security scan
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write    # requerido para subir SARIF al tab de Security
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- `label-check` y `security`: agregar `contents: read` (faltaba — al declarar bloque `permissions` se restringen los implícitos, y checkout fallaba con 404).
- `lint-build`: exportar `NEXUS_USER`/`NEXUS_PASSWORD` como env del job (sbt los lee desde `build.sbt` para `credentials()`).

Detectado al validar acp-api#6.

## Test plan
- [ ] Mover tag `v2` y re-correr CI de acp-api#6 — los 5 jobs deben pasar.