### PR TITLE
fix: sbt vía coursier + excluir workflows del scan de secrets

### DIFF
--- a/.github/actions/backend/scala/lint-build/action.yml
+++ b/.github/actions/backend/scala/lint-build/action.yml
@@ -16,10 +16,12 @@ runs:
         java-version: ${{ inputs.java-version }}
         cache: sbt
 
-    - name: Setup sbt
-      uses: sbt/setup-sbt@v1
+    - name: Setup sbt (vía coursier)
+      # sbt/setup-sbt@v1 está roto: descarga zips vacíos desde release-assets.githubusercontent.com.
+      # Coursier instala sbt sin pasar por ese endpoint.
+      uses: coursier/setup-action@v1
       with:
-        sbt-runner-version: "1.11.6"   # 1.12.8 (default) tiene release roto upstream — pinear hasta que se resuelva
+        apps: sbt
 
     - name: Format check (scalafmt)
       shell: bash

--- a/.github/actions/shared/security-scan/action.yml
+++ b/.github/actions/shared/security-scan/action.yml
@@ -43,7 +43,12 @@ runs:
           }
         fi
         pip install "detect-secrets>=1.4.0,<2.0.0" --quiet
-        detect-secrets scan --all-files . > secrets-baseline.json
+        # Excluir .git/ (artefactos del clone) y .github/workflows/ (refs ${{ secrets.X }}
+        # que detect-secrets clasifica como high-entropy strings).
+        detect-secrets scan --all-files . \
+          --exclude-files '^\.git/' \
+          --exclude-files '^\.github/workflows/' \
+          > secrets-baseline.json
         python3 -c "
         import json, sys
         data = json.load(open('secrets-baseline.json'))


### PR DESCRIPTION
## Summary
- `lint-build`: `sbt/setup-sbt@v1` está roto upstream (zip vacío); usar `coursier/setup-action@v1` con `apps: sbt`.
- `security-scan`: `detect-secrets` flagea `.git/` y los workflow YAML por las refs `${{ secrets.X }}`. Excluir ambos paths.

## Test plan
- [ ] Mover tag `v2` y re-correr CI de acp-api#6 — los 5 jobs deben pasar.