### PR TITLE
fix: escapar comentario en security-scan

### DIFF
--- a/.github/actions/shared/security-scan/action.yml
+++ b/.github/actions/shared/security-scan/action.yml
@@ -43,8 +43,8 @@ runs:
           }
         fi
         pip install "detect-secrets>=1.4.0,<2.0.0" --quiet
-        # Excluir .git/ (artefactos del clone) y .github/workflows/ (refs ${{ secrets.X }}
-        # que detect-secrets clasifica como high-entropy strings).
+        # Excluir .git/ (artefactos del clone) y .github/workflows/
+        # (las refs a secrets son detectadas como high-entropy strings).
         detect-secrets scan --all-files . \
           --exclude-files '^\.git/' \
           --exclude-files '^\.github/workflows/' \


### PR DESCRIPTION
El comentario contenía `${{ secrets.X }}` literal y GH Actions intenta interpretarlo como expresión, fallando con 'Unrecognized named-value: secrets'.