### PR TITLE
fix: env Nexus a nivel job en publish-deploy y make-release

### DIFF
--- a/.github/workflows/scala-api-make-release.yml
+++ b/.github/workflows/scala-api-make-release.yml
@@ -44,6 +44,10 @@ jobs:
     permissions:
       contents: write             # requerido para crear tags y hacer push de ramas
       security-events: write      # requerido para subir SARIF al tab de Security
+    env:
+      TZ: America/Montevideo
+      NEXUS_USER: ${{ secrets.NEXUS_USER }}
+      NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/scala-api-publish-deploy.yml
+++ b/.github/workflows/scala-api-publish-deploy.yml
@@ -29,6 +29,10 @@ jobs:
     name: Publish JAR snapshot → Nexus + deploy testing/staging
     runs-on: ubuntu-latest
     environment: ${{ startsWith(github.ref, 'refs/heads/hotfix/') && 'staging' || 'testing' }}
+    env:
+      TZ: America/Montevideo
+      NEXUS_USER: ${{ secrets.NEXUS_USER }}
+      NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Mismo bug ya arreglado en `scala-api-ci.yml`: `build.sbt` lee credentials al cargar, así que `NEXUS_USER`/`NEXUS_PASSWORD` deben estar en el job env, no solo en el step de publish.

Detectado al mergear acp-api#6 y disparar publish-and-deploy en develop.