### PR TITLE
feat: scala-api-publish-rc workflow + convención versionado v2

### DIFF
--- a/.github/actions/shared/github-release/action.yml
+++ b/.github/actions/shared/github-release/action.yml
@@ -5,6 +5,10 @@ inputs:
   tag:
     description: Tag a publicar
     required: true
+  prerelease:
+    description: Marcar como pre-release (RC). Si true, no se marca como 'latest'.
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -14,4 +18,5 @@ runs:
       with:
         tag_name: ${{ inputs.tag }}
         generate_release_notes: true
-        make_latest: true
+        prerelease: ${{ inputs.prerelease }}
+        make_latest: ${{ inputs.prerelease == 'true' && 'false' || 'true' }}

--- a/.github/workflows/scala-api-publish-rc.yml
+++ b/.github/workflows/scala-api-publish-rc.yml
@@ -1,0 +1,95 @@
+name: Scala API · Publish RC (reusable)
+
+# Reusable workflow v2 — invocar desde el repo cliente con:
+#
+#   on:
+#     workflow_dispatch:
+#   jobs:
+#     publish-rc:
+#       uses: BQN-UY/CI-CD/.github/workflows/scala-api-publish-rc.yml@v2
+#       secrets: inherit
+#
+# Sólo se permite disparar desde release/** o hotfix/**.
+# Calcula el próximo rc.N a partir de los tags existentes para esa
+# versión base (extraída del nombre de la rama), lo crea y publica el
+# JAR a Nexus + GitHub pre-release. NO hace deploy — el deploy es
+# responsabilidad del workflow GA-native cuando esté disponible.
+
+on:
+  workflow_call:
+    inputs:
+      java-version:
+        description: Versión de Java para sbt
+        required: false
+        type: string
+        default: "21"
+
+jobs:
+  publish-rc:
+    name: Tag rc.N + publish a Nexus + GitHub pre-release
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref_name, 'release/') || startsWith(github.ref_name, 'hotfix/')
+    permissions:
+      contents: write             # crear y pushear el tag, crear el GitHub release
+    env:
+      TZ: America/Montevideo
+      NEXUS_USER: ${{ secrets.NEXUS_USER }}
+      NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0          # historial completo para tags y sbt-dynver
+
+      - name: Extraer versión base desde nombre de rama
+        id: base
+        shell: bash
+        run: |
+          # Soporta release/vX.Y.Z y hotfix/vX.Y.Z-descripcion
+          BASE=$(echo "${GITHUB_REF_NAME}" | grep -oP '(?<=/)v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 | sed 's/^v//')
+          if [ -z "$BASE" ]; then
+            echo "Error: no se pudo extraer versión X.Y.Z desde '${GITHUB_REF_NAME}'. Formato esperado: release/vX.Y.Z o hotfix/vX.Y.Z-desc" >&2
+            exit 1
+          fi
+          echo "version=$BASE" >> "$GITHUB_OUTPUT"
+
+      - name: Calcular próximo rc.N
+        id: rc
+        shell: bash
+        env:
+          BASE: ${{ steps.base.outputs.version }}
+        run: |
+          set -euo pipefail
+          git fetch --tags --prune
+          LAST_N=$(git tag --list "v${BASE}-rc.*" \
+            | sed -n "s/^v${BASE}-rc\.\([0-9]\+\)$/\1/p" \
+            | sort -n | tail -1)
+          NEXT=$(( ${LAST_N:-0} + 1 ))
+          TAG="v${BASE}-rc.${NEXT}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Próximo RC: $TAG (anterior: ${LAST_N:-ninguno})" >&2
+
+      - name: Crear y pushear tag RC
+        shell: bash
+        env:
+          TAG: ${{ steps.rc.outputs.tag }}
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release candidate $TAG"
+          git push origin "$TAG"
+
+      - uses: BQN-UY/CI-CD/.github/actions/backend/scala/lint-build@v2
+        with:
+          java-version: ${{ inputs.java-version }}
+
+      - name: Publish RC JAR → Nexus
+        shell: bash
+        run: sbt publish
+
+      - name: GitHub pre-release
+        uses: BQN-UY/CI-CD/.github/actions/shared/github-release@v2
+        with:
+          tag: ${{ steps.rc.outputs.tag }}
+          prerelease: "true"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,14 @@ docs/                 ← documentación de referencia v2
 | `hotfix/**` | staging | Fix urgente — espejo de producción |
 | `make-release` | production | Único deploy irreversible |
 
+## Convención de versionado (v2)
+
+- **Snapshots dynver** (cualquier push): `X.Y.Z-N-sha` — separador `-`, NUNCA `+` (Nexus rechaza `%2B` y SemVer ignora `+` al ordenar).
+- **Release candidate**: tag `vX.Y.Z-rc.N` creado por `scala-api-publish-rc.yml` (workflow_dispatch en release/** o hotfix/**). N arranca en 1, se autoincrementa por iteración.
+- **Release final**: tag `vX.Y.Z` creado por `scala-api-make-release.yml` al promover a producción.
+
+Cada proyecto Scala debe declarar `ThisBuild / dynverSeparator := "-"` en `build.sbt`.
+
 ## Cómo agregar una nueva action v2
 
 1. Decidir capa: ¿`shared/`, `frontend/<stack>/` o `backend/<stack>/`?

--- a/docs/migration-v2.md
+++ b/docs/migration-v2.md
@@ -161,10 +161,21 @@ A partir de v2, además de las composite actions, hay **reusable workflows** que
 |---|---|---|
 | `scala-api-ci.yml` | API Scala | `pull_request` + `push` release/hotfix |
 | `scala-api-publish.yml` | API Scala | `push` develop / release / hotfix |
+| `scala-api-publish-rc.yml` | API Scala | `workflow_dispatch` (release/hotfix) |
 | `scala-api-make-release.yml` | API Scala | `workflow_dispatch` |
 | `scala-api-start-release.yml` | API Scala | `workflow_dispatch` |
 | `scala-api-start-hotfix.yml` | API Scala | `workflow_dispatch` |
 | `setup-labels.yml` | Cualquiera | `workflow_dispatch` |
+
+### Versionado y release candidates
+
+Convención v2:
+
+- **Snapshots dynver** (cualquier push a `develop`/`release/**`/`hotfix/**`): `X.Y.Z-N-sha` con separador `-`. Cada proyecto Scala debe declarar `ThisBuild / dynverSeparator := "-"` en `build.sbt` — el default `+` es rechazado por Nexus (URL-encoded `%2B`) y SemVer 2.0.0 lo trata como build-metadata ignorado al ordenar.
+- **Release candidate**: tag `vX.Y.Z-rc.N` creado por `scala-api-publish-rc.yml`. La iteración `N` se calcula automáticamente: si no hay tags previos para esa versión base arranca en `1`, si existen `rc.1`, `rc.2`, … crea el siguiente. Publica el JAR a Nexus y crea un GitHub pre-release.
+- **Release final**: tag `vX.Y.Z` creado por `scala-api-make-release.yml`. Publica el JAR a Nexus, crea el GitHub release marcado como `latest`, hace back-merge a develop. Los `rc.N` previos quedan como pre-releases en el historial.
+
+> **Deploy**: ningún workflow v2 contiene step de deploy desde Hito 1 (ver `docs/v2-sin-jenkins-roadmap.md`). Los entornos testing/staging/production se actualizan vía workflow GA-native cuando esté disponible (Hito 3); proyectos en v1 siguen usando Jenkins.
 
 ### Caller mínimo
 

--- a/templates/scala-api/publish-rc.yml
+++ b/templates/scala-api/publish-rc.yml
@@ -1,0 +1,15 @@
+name: Publish RC
+
+# Publica un release candidate (vX.Y.Z-rc.N) desde una release/** o hotfix/**.
+# El número rc.N se calcula automáticamente: si ya existen tags vX.Y.Z-rc.1, rc.2…
+# se crea el siguiente. Caso inicial: rc.1.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish-rc:
+    uses: BQN-UY/CI-CD/.github/workflows/scala-api-publish-rc.yml@v2
+    secrets: inherit
+    # with:
+    #   java-version: "21"


### PR DESCRIPTION
## Summary
Nuevo reusable workflow `scala-api-publish-rc.yml` para publicar release candidates explícitos desde `release/**` o `hotfix/**` (workflow_dispatch). El número `rc.N` se autocalcula desde tags existentes para esa versión base.

Sin step de deploy — alineado con dirección Escenario C (v2 deja de invocar Jenkins). El deploy queda en su workflow GA-native cuando esté listo; mientras tanto sigue por la pipeline v1.

## Cambios
- **`.github/workflows/scala-api-publish-rc.yml`** (nuevo): tag `vX.Y.Z-rc.N` + lint-build + `sbt publish` + GitHub pre-release.
- **`templates/scala-api/publish-rc.yml`** (nuevo): caller corto.
- **`shared/github-release`**: input `prerelease` (default false); cuando true, `make_latest=false`.
- **`CLAUDE.md`, `docs/migration-v2.md`**: convención de versionado:
  - `ThisBuild / dynverSeparator := "-"` obligatorio en `build.sbt` (Nexus rechaza `+`/`%2B`; SemVer 2.0.0 ignora `+` al ordenar)
  - RC: `vX.Y.Z-rc.N` (N arranca en 1, autoincrementa)
  - Final: `vX.Y.Z`

## Test plan
- [ ] Mover tag `v2` y probar `publish-rc` en una release branch de acp-api (tras mergear acp-api#8 con `dynverSeparator`)