### PR TITLE
docs: spec del Hito 2 (deploy GA-native) — borrador

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,16 +1,42 @@
 # Copilot instructions — BQN-UY/CI-CD
 
+> **Doc canónico**: `docs/v2-hito2-deploy-spec.md`. Si hay conflicto, ese gana.
+
 ## Qué es este repo
 
-Repositorio centralizado de CI/CD. Las composite actions v2 viven en `.github/actions/`.
-Los reusable workflows v1 (legacy) viven en `.github/workflows/` — no modificar.
+Repositorio centralizado de CI/CD. Composite actions v2 viven en `.github/actions/`. Reusable workflows v2 (con prefijo `<stack>-`) viven en `.github/workflows/`. Workflows sin prefijo en `.github/workflows/` son **v1 legacy** — no modificar.
+
+## Principio rector v2
+
+**v2 NO depende de `BQN-UY/jenkins`.** Workflows v2 nuevos NO invocan `jenkins-deploy-trigger`, NO leen `sistemas.json`, NO usan secrets `JENKINS_DEPLOY_*`. El composite `shared/jenkins-deploy-trigger` se conserva sólo por compatibilidad con repos en v1.
 
 ## Reglas estrictas
 
-- Solo modificar `.github/actions/`, `templates/` y `docs/`
-- NUNCA tocar `.github/workflows/` (legacy v1)
-- Los workflows de proyecto no viven aquí — viven en cada repo de proyecto
-- Ambientes válidos en jenkins-deploy-trigger: `testing`, `staging`, `production`
+- Modificar: `.github/actions/`, `.github/workflows/<stack>-*.yml`, `templates/`, `docs/`
+- NO tocar workflows en `.github/workflows/` sin prefijo `<stack>-` (v1 legacy)
+- Los workflows ejecutables de cada proyecto NO viven aquí — viven en cada repo y son callers cortos al reusable
+
+## Tres grupos de proyectos
+
+| Grupo | Storage | Versionado |
+|---|---|---|
+| Server apps (APIs/WARs/python) | **GH Releases** | `v<NEXT>-snapshot.NNN`, `vX.Y.Z-rc.NNN`, `vX.Y.Z` |
+| Client apps (BPos/GPos/IDH) | TBD (probablemente GH Releases) | TBD |
+| Libs (scala libs) | **Nexus** | `<base>-SNAPSHOT` Maven-standard |
+
+## Versionado v2 server apps
+
+- push develop → `v<NEXT>-snapshot.NNN` (NEXT = last_final + bump leído de `.github/next-bump`)
+- push release/hotfix → `vX.Y.Z-rc.NNN` (auto en push, NO hay workflow_dispatch publish-rc)
+- make-release → `vX.Y.Z` (final, marcado `latest`)
+- NNN: 3 dígitos zero-padded, auto-incrementa
+- Cleanup: workflow daily conserva últimos 3 snapshots por target
+
+## Tag protection en repos app
+
+- `v[0-9]*` → protegido (releases finales inmutables)
+- `v*-rc.*` → protegido (RCs auditados inmutables)
+- `v*-snapshot.*` → libre (cleanup borra)
 
 ## Estructura de una action v2
 
@@ -18,20 +44,28 @@ Los reusable workflows v1 (legacy) viven en `.github/workflows/` — no modifica
 .github/actions/<capa>/<stack>/<nombre>/action.yml
 ```
 
-Capas: `shared/` (agnóstico de stack) | `frontend/<stack>/` | `backend/<stack>/`
+Capas: `shared/` (agnóstico) | `frontend/<stack>/` | `backend/<stack>/`
 
-## Semántica de ambientes
+## Ambientes (deploy v2 server apps, vía GA-native cuando esté listo)
 
 | Rama | Ambiente |
 |---|---|
-| `develop`, `release/**` | testing |
-| `hotfix/**` | staging |
+| `develop` | testing |
+| `release/**`, `hotfix/**` | staging |
 | `make-release` | production |
 
-## Secrets y variables de deploy
+## Para libs (Maven en Nexus)
 
-Org-level (BQN-UY): `JENKINS_DEPLOY_URL`, `JENKINS_DEPLOY_TESTING_TOKEN`, `JENKINS_DEPLOY_STAGING_TOKEN`, `JENKINS_DEPLOY_PRODUCTION_TOKEN`
+Las libs siguen modelo standard. Cada `build.sbt` debe declarar:
+```scala
+ThisBuild / dynverSeparator         := "-"
+ThisBuild / dynverSonatypeSnapshots := true
+```
 
-Repo-level variable: `vars.SISTEMA` (nombre del servicio, ej. `payments-api`)
+Apps NO usan estas settings (no publican a Nexus).
 
-El token va como `?token=` en la URL — GWT lo usa para rutear al job Jenkins correcto. Ver `docs/jenkins.md`.
+## Referencia
+
+- Spec canónico: `docs/v2-hito2-deploy-spec.md`
+- Roadmap sin Jenkins: `docs/v2-sin-jenkins-roadmap.md`
+- Catálogo workflows: `docs/migration-v2.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,12 +3,14 @@
 Repositorio centralizado de CI/CD de la organización BQN-UY.
 Contiene composite actions reutilizables (v2), reusable workflows v2 y los reusable workflows heredados (v1).
 
+> **Documento canónico del modelo v2**: `docs/v2-hito2-deploy-spec.md`. Si hay conflicto entre cualquier documento y el spec, **el spec gana**. Este CLAUDE.md condensa lo operativo.
+
 ## Estructura del repo
 
 ```
 .github/
 ├── actions/          ← composite actions v2  — MODIFICAR AQUÍ
-│   ├── shared/       ← lógica agnóstica de stack (jenkins-deploy-trigger, semver-tag, etc.)
+│   ├── shared/       ← lógica agnóstica de stack (semver-tag, github-release, security-scan, etc.)
 │   ├── frontend/     ← acciones por stack frontend (html-js, vaadin, flutter)
 │   └── backend/      ← acciones por stack backend (scala, python, node)
 └── workflows/        ← convive v1 (legacy) y v2 (reusable workflows)
@@ -31,31 +33,57 @@ docs/                 ← documentación de referencia v2
 - Toda nueva action v2 va en `.github/actions/<capa>/<stack>/<nombre>/action.yml`
 - Todo nuevo reusable workflow v2 va en `.github/workflows/<stack>-<tipo>-<workflow>.yml` con `on: workflow_call`
 
-## Ambientes válidos (`shared/jenkins-deploy-trigger`)
+## Principio rector v2
 
-`testing` | `staging` | `production`
+**v2 no depende de `BQN-UY/jenkins` para nada.** Ese repo (rama `production`, scripts groovy, `sistemas.json`) queda congelado como legacy v1. Workflows v2 nuevos NO invocan `jenkins-deploy-trigger`, NO leen archivos del repo jenkins, NO referencian secrets `JENKINS_DEPLOY_*`. Ver `docs/v2-sin-jenkins-roadmap.md`.
 
-## Semántica de ambientes
+> El composite `shared/jenkins-deploy-trigger` se conserva por compatibilidad con repos aún en v1, pero NO se usa en código nuevo de v2.
+
+## Tres grupos de proyectos
+
+| Grupo | Ejemplos | Storage de artefactos | Versionado |
+|---|---|---|---|
+| **Server apps** | scala APIs, WARs, python servers | **GH Releases** del propio repo | `v<NEXT>-snapshot.NNN` / `vX.Y.Z-rc.NNN` / `vX.Y.Z` |
+| **Client apps** | BPos, GPos, IDH (firmwares) | TBD (probablemente GH Releases) | TBD por equipo |
+| **Libs** | scala libs, protocolos | **Nexus** maven-snapshots / maven-releases | `<base>-SNAPSHOT` (Maven-standard) |
+
+Detalle completo en `docs/v2-hito2-deploy-spec.md` §1.
+
+## Convención de versionado v2 (server apps)
+
+| Trigger | Tag GH | Tipo | Cleanup |
+|---|---|---|---|
+| push `develop` | `v<NEXT>-snapshot.NNN` | pre-release | sí (workflow daily, conserva últimos 3 por target) |
+| push `release/vX.Y.Z` o `hotfix/vX.Y.Z-desc` | `vX.Y.Z-rc.NNN` | pre-release | no |
+| `make-release` (workflow_dispatch) | `vX.Y.Z` | release final | no |
+
+- **NNN**: 3 dígitos zero-padded (`001`, `002`, ...), auto-incrementa por trigger
+- **`<NEXT>`**: derivada de `last_final_tag + bump`, donde `bump ∈ {minor, major}` se lee de `.github/next-bump` (default `minor`)
+- **RCs son auto en push** (no hay `publish-rc` workflow_dispatch separado)
+- `.github/next-bump` lo actualiza un workflow al merger PRs con label `breaking-change`; `make-release` lo resetea a `minor`
+
+> **NO confundir con libs**: las libs siguen el modelo Maven-standard `<base>-SNAPSHOT` en Nexus. La convención de arriba es para server apps.
+
+## Tag protection requerida en repos app
+
+| Patrón | Protegido contra | Razón |
+|---|---|---|
+| `v[0-9]*` | delete + force-push | releases finales son inmutables |
+| `v*-rc.*` | delete + force-push | RCs auditados son inmutables |
+| `v*-snapshot.*` | (libre) | cleanup workflow necesita borrarlos |
+
+## Ambientes (deploy v2 server apps)
 
 | Rama del proyecto | Ambiente | Propósito |
 |---|---|---|
-| `develop` | testing | Features de la próxima versión |
-| `release/**` | testing | Fixes del release en curso |
-| `hotfix/**` | staging | Fix urgente — espejo de producción |
-| `make-release` | production | Único deploy irreversible |
+| `develop` | testing | Features de la próxima versión (auto-deploy desde snapshot) |
+| `release/**` | staging | Validación del RC (auto-deploy desde rc) |
+| `hotfix/**` | staging | Fix urgente — espejo de producción (auto-deploy desde rc) |
+| `make-release` | production | Único deploy irreversible (manual por Soporte) |
 
-## Convención de versionado (v2)
+> Mecanismo concreto del deploy GA-native: pendiente de Hito 2/3. Ver `docs/v2-hito2-deploy-spec.md`.
 
-- **Snapshots dynver** (cualquier push entre tags): `X.Y.Z-SNAPSHOT` (formato Maven). El repo Nexus `maven-snapshots` requiere el sufijo `-SNAPSHOT`.
-- **Release candidate**: tag `vX.Y.Z-rc.N` creado por `scala-api-publish-rc.yml` (workflow_dispatch en release/** o hotfix/**). N arranca en 1, se autoincrementa por iteración.
-- **Release final**: tag `vX.Y.Z` creado por `scala-api-make-release.yml` al promover a producción.
-
-Cada proyecto Scala debe declarar en `build.sbt`:
-
-```scala
-ThisBuild / dynverSeparator         := "-"   // evita '+' (Nexus rechaza %2B; SemVer lo ignora al ordenar)
-ThisBuild / dynverSonatypeSnapshots := true  // formato Maven '<base>-SNAPSHOT' entre tags
-```
+> Composite legacy `shared/jenkins-deploy-trigger` admite ambientes `testing | staging | production` para repos aún en v1.
 
 ## Cómo agregar una nueva action v2
 
@@ -73,6 +101,8 @@ ThisBuild / dynverSonatypeSnapshots := true  // formato Maven '<base>-SNAPSHOT' 
 
 ## Referencia
 
+- **Spec canónico v2 (server apps)**: `docs/v2-hito2-deploy-spec.md`
+- Hoja de ruta v2 sin Jenkins: `docs/v2-sin-jenkins-roadmap.md`
 - Documentación completa: `docs/migration-v2.md`
 - Guía de migración Scala: `docs/scala-migration-v2.md`
 - Workflows v1 (legacy): `docs/workflows-v1.md`

--- a/docs/v2-hito2-deploy-spec.md
+++ b/docs/v2-hito2-deploy-spec.md
@@ -1,155 +1,219 @@
-# Hito 2 — Spec del deploy GA-native (borrador)
+# Hito 2 — Spec del deploy GA-native
 
-> Estado: **borrador para discusión** · Tracking: `docs/v2-sin-jenkins-roadmap.md` Hito 2
+> Estado: **borrador en discusión** · Tracking: `docs/v2-sin-jenkins-roadmap.md` Hito 2
 
-Documento para alinear el diseño del workflow de deploy GA-native que reemplaza a Jenkins en v2.
-Contiene: requisitos heredados de v1, decisiones de diseño abiertas, y criterios de aceptación.
+Documento canónico del diseño del deploy GA-native que reemplaza a Jenkins en v2. Captura: principios, modelo de artefactos, convención de versionado, requisitos heredados de v1, decisiones tomadas y decisiones abiertas.
 
 ## Principio rector
 
-**v2 no depende de `BQN-UY/jenkins` para nada.** Ese repo (incluyendo su rama `production`, los scripts groovy, `sistemas.json`, etc.) es legacy de v1 y queda congelado. v2 lee la lógica de v1 sólo como referencia para entender requisitos — pero ningún workflow ni runner GA invoca, importa o lee archivos de ese repo.
+**v2 no depende de `BQN-UY/jenkins` para nada.** Ese repo (rama `production`, scripts groovy, `sistemas.json`, etc.) queda congelado como legacy v1. v2 lee su lógica sólo como referencia descriptiva — ningún workflow, runner, ni script invoca, importa o lee archivos de ese repo.
 
 ---
 
-## 1. Baseline — qué hace el deploy v1 (Jenkins)
+## 1. Tres grupos de proyectos
 
-Resumen de `~/projects/bqn/jenkins/CI_CD/deploy-nexus.groovy` (319 líneas, pipeline declarativo).
-**Esta sección es descriptiva** — captura qué requisitos hay que cubrir en v2. v2 NO lee, ejecuta, ni invoca código del repo `BQN-UY/jenkins` (ver Principio rector).
+| Grupo | Ejemplos | Distribución | Versionado | Storage |
+|---|---|---|---|---|
+| **Server apps** | scala APIs, WARs, python servers | Auto-deploy a testing/staging/production por GA + runner self-hosted | `vX.Y.Z[-snapshot|-rc].NNN` | **GH Releases** del propio repo |
+| **Client apps** | BPos, GPos, IDH (firmwares) | Instalación manual en equipos externos | TBD por equipo | TBD (probablemente GH Releases) |
+| **Libs** | scala libs, protocolos comunes | Consumidas por builds | `<base>-SNAPSHOT` (Maven-standard) | **Nexus** `maven-snapshots` / `maven-releases` |
 
-**Inputs** (por webhook GWT desde GitHub Actions):
-- `SISTEMA` — nombre del sistema, debe coincidir con `sistemas.json`
-- `VERSION` — sbt-dynver (snapshot o release) o tag explícito
-- `ENVIRONMENT` — `testing` | `staging` | `production`
-- `ACTOR` — github actor que disparó el deploy
-- `INSTALLATION` — coma-separado, vacío = todas las que tengan `auto_deploy: true`
-- `RESTORE` — bool, restaurar DB antes (solo testing/staging)
+Este Hito 2 cubre **server apps**. Client apps y libs se documentan en sus propios specs/templates cuando corresponda.
+
+---
+
+## 2. Modelo de artefactos para server apps
+
+### 2.1 Storage: GitHub Releases (no Nexus)
+
+Los apps **no publican a Nexus**. Cada artefacto generado por CI vive como adjunto de un GitHub Release/Pre-release del propio repo:
+
+- Auth simplificada: `GITHUB_TOKEN` del runner; sin credenciales Nexus.
+- Single source of truth por proyecto: artefacto + git tag + release notes + sha en un solo lugar.
+- Interfaz uniforme para deploy: `gh release download <tag>` para todo (testing, staging, production).
+- Convergencia con el modelo natural de client apps (BPos/GPos/IDH también vivirían bien acá).
+
+### 2.2 Convención de versionado
+
+| Trigger | Tag GH | Tipo | Cleanup |
+|---|---|---|---|
+| push `develop` | `v<NEXT>-snapshot.NNN` | pre-release | sí (workflow) |
+| push `release/vX.Y.Z` o `hotfix/vX.Y.Z-desc` | `vX.Y.Z-rc.NNN` | pre-release | no |
+| `make-release` (workflow_dispatch) | `vX.Y.Z` | release final | no |
+
+- **NNN**: 3 dígitos zero-padded (`001`, `002`, ..., `999`), auto-incrementa por trigger
+- **`<NEXT>`**: versión target en develop, derivada de `last_final_tag + bump` donde `bump ∈ {minor, major}`
+- **rc.NNN**: cada push a release/hotfix genera el siguiente RC automáticamente (no más `publish-rc` workflow_dispatch deliberado)
+- Los snapshots y RCs son **pre-releases** en GH; los finales son releases marcados `latest`
+
+### 2.3 `.github/next-bump` — el bump del próximo release
+
+Archivo en cada repo app, contenido: `minor` (default) o `major`.
+
+**Quién lo actualiza**:
+- Reusable workflow `update-next-bump.yml` (stack-agnóstico): se dispara en cada PR mergeado a develop. Si el PR tiene label `breaking-change` y el archivo dice `minor`, lo cambia a `major`, commit + push.
+- `make-release.yml`: lee el archivo, aplica el bump al último final tag para calcular el target del release, y resetea el archivo a `minor` para el próximo ciclo.
+
+**Edición manual permitida**: humanos pueden editar el archivo entre releases si la política cambió (p.ej., un breaking PR fue revertido y queremos volver a `minor`).
+
+### 2.4 Cleanup de snapshots
+
+Workflow `cleanup-snapshots.yml` (cron diario) por proyecto:
+- Conserva **últimos 3** pre-releases con tag `v*-snapshot.*` por target version
+- Borra el resto (pre-release + tag git asociado)
+- RCs y releases finales nunca se tocan
+
+### 2.5 Tag protection
+
+Reglas en cada repo app (GH Settings → Tag protection):
+- `v[0-9]*` (releases finales) → protegido contra delete y force-push
+- `v*-rc.*` (RCs) → protegido contra delete y force-push
+- `v*-snapshot.*` → libre (cleanup necesita borrarlos)
+
+---
+
+## 3. Baseline — qué hace el deploy v1 (Jenkins)
+
+> **Sección descriptiva** — captura requisitos a cubrir, no dependencias de v2.
+
+Resumen de `deploy-nexus.groovy` del repo `BQN-UY/jenkins`:
+
+**Inputs** (por webhook GWT desde GitHub Actions): `SISTEMA`, `VERSION`, `ENVIRONMENT`, `ACTOR`, `INSTALLATION`, `RESTORE`.
 
 **Flujo:**
-1. Carga `sistemas.json` desde `BQN-UY/jenkins/config/sistemas.json` (PAT GitHub).
-2. Resuelve `installations` para el `(sistema, environment)` solicitado.
-3. Notifica inicio a Google Chat (webhook).
-4. Si production → `input` manual con submitter restringido (`admins,soporte,auxiliar_soporte`).
-5. Si `RESTORE` y no production → invoca `IDS/restoreDB`.
-6. **Por cada instalación, en paralelo:**
-   - Resuelve URL exacta del artefacto en Nexus vía Search API (necesario por el sufijo Scala `_2.13` y el timestamp Maven en snapshots).
-   - Se conecta al **endpoint Portainer** correspondiente (cada instalación tiene su `portainer_endpoint` y `portainer_container`).
-   - Stop container.
-   - Descarga JAR/WAR desde Nexus a `localFile`.
-   - Copia a `deploy_path/target_name` (default `/opt/webapps`).
+1. Carga `sistemas.json`.
+2. Resuelve `installations` para el `(sistema, environment)`.
+3. Notifica inicio a Google Chat.
+4. Si production → `input` manual con submitter restringido.
+5. Si `RESTORE` → invoca `IDS/restoreDB`.
+6. Por cada instalación, paralelo:
+   - Resuelve URL del artefacto en Nexus (Search API).
+   - Stop container (Portainer API).
+   - Descarga JAR/WAR a localFile.
+   - Copia a `deploy_path/target_name`.
    - Start container.
-7. Registra el deploy en `deploy-registry` (success/failure por instalación).
-8. Notifica fin a Google Chat.
+7. Registra deploy.
+8. Notifica fin.
 
-**Dependencias técnicas:**
-- Portainer API (token `portainer_jenkins_token`).
-- Nexus (credenciales `nexus_deploy`).
-- `sistemas.json` con schema: `apps[].environments[].installations[]` con `name`, `portainer_endpoint`, `portainer_container`, `artifact.{extension, deploy_path, target_name}`, `auto_deploy`.
-- Google Chat webhook por ambiente.
-- Jenkins agents en cada `portainer_endpoint` (el `cp` corre **localmente en el host destino**, no remoto — por eso se usa `node(pEndpoint)`).
-- `deploy-registry` (servicio interno).
-- `IDS/restoreDB` (job Jenkins separado).
+**Dependencias técnicas que v2 debe replicar (con tecnologías GA-native):**
+- Acceso a Portainer (token).
+- Acceso a artefactos (en v2: `gh release download` con `GITHUB_TOKEN`).
+- Mapping `sistema → instalaciones → endpoints/containers/paths`.
+- Notificaciones (Google Chat — se mantiene).
+- Registro de deploys (en v2: GitHub Deployments API).
+- Aprobación production (en v2: GH Environments required reviewers).
 
 ---
 
-## 2. Decisiones de diseño abiertas
+## 4. Decisiones tomadas
 
-### 2.1 Self-hosted runner GA — ¿dónde y cuántos?
+### 4.1 Modelo de artefactos
+✅ Server apps usan **GitHub Releases** (no Nexus).  
+✅ Libs siguen en **Nexus** con formato Maven-standard `<base>-SNAPSHOT`.
 
-El runner GA reemplaza al "Jenkins agent" del modelo v1. Necesita:
-- Acceso de red a Portainer (todos los endpoints), Nexus, NAS2, DBs.
-- Capacidad de ejecutar `curl` + `cp` (mínimo).
-- Token efímero a GitHub (auto-gestionado por el runner).
+### 4.2 Versionado
+✅ `vX.Y.Z-snapshot.NNN` / `vX.Y.Z-rc.NNN` / `vX.Y.Z` con NNN auto-incremental.  
+✅ `.github/next-bump` con valores `minor|major`, mantenido por workflow + reseteo en make-release.  
+✅ RCs auto en push (sin workflow_dispatch separado).
+
+### 4.3 Cleanup y tag protection
+✅ Cleanup: últimos **3** snapshots por target (workflow daily).  
+✅ Tag protection: `v[0-9]*` y `v*-rc.*` protegidos; `v*-snapshot.*` libres.
+
+### 4.4 Modelo de "instalaciones" para deploy
+✅ **B + C combinados**:
+- `.github/deploy.json` (o `.yml`) en cada repo: lista de instalaciones por environment (`portainer_endpoint`, `portainer_container`, `deploy_path`, `target_name`, `auto_deploy`). Versionado con el código.
+- GH Environments por env (testing/staging/production): secrets/tokens/URLs sensibles, required reviewers para production.
+
+### 4.5 Aprobación production
+✅ GH Environments `required reviewers`.  
+🟡 Pendiente confirmar lista de submitters (mantener `admins,soporte,auxiliar_soporte` o ajustar).
+
+### 4.6 Notificaciones
+✅ Mantener Google Chat (continuidad con Soporte).
+
+### 4.7 Registro de deploys
+✅ **GitHub Deployments API** (nativo). Cada deploy crea un Deployment con env, ref, status. Sin servicio nuevo.
+
+### 4.8 Restore DB
+✅ Fuera de scope Hito 2 — se aborda en hito propio (operativos en GA, alineado con informe Jenkins §10 Fase 3).
+
+---
+
+## 5. Decisiones abiertas (input de Soporte/IDS)
+
+### 5.1 Self-hosted runner GA — ¿dónde y cuántos?
 
 | Opción | Pros | Contras |
 |---|---|---|
-| **A. Un runner único** en `DEPLOY_IP` | Mínimo a operar; ya está en red interna (acceso a todo) | SPOF; el `cp` al host destino debe ser **remoto** (SSH), no local — distinto al modelo v1 |
-| **B. Un runner por endpoint Portainer** (espejo de Jenkins agents) | `cp` local al host (igual que v1); paraleliza naturalmente | N runners a instalar/mantener (~5-10); más superficie de ataque |
-| **C. Runners "labeled"** (subset estratégico, ej. uno por DC físico) | Equilibrio: paralelismo + menos superficie | Diseñar el labeling y el routing del job; complejidad media |
+| **A. Un runner único** (en `DEPLOY_IP` u otro host) | Mínimo a operar | SPOF; el `cp` al host destino debe ser remoto (SSH) |
+| **B. Un runner por endpoint Portainer** | `cp` local; paraleliza naturalmente | N runners a mantener; más superficie |
+| **C. Runners labeled** (subset, p.ej. uno por DC) | Equilibrio paralelismo/superficie | Diseñar labeling y routing |
 
-> **Pregunta para Soporte/IDS**: ¿cuántos `portainer_endpoint` distintos hay hoy en `sistemas.json`?
-> ¿Están en el mismo DC? Si sí, A simplifica mucho. Si están distribuidos geográficamente, C es la respuesta natural.
+> **Pregunta**: ¿cuántos `portainer_endpoint` distintos hay hoy y cómo están distribuidos geográficamente?
 
-### 2.2 Mecanismo de deploy — ¿cómo llegamos al artefacto en el container?
-
-Tres caminos limpios:
+### 5.2 Mecanismo de deploy — ¿cómo llegamos al artefacto en el container?
 
 | Opción | Cómo funciona | Encaja si |
 |---|---|---|
-| **α. Portainer API** (HTTP + token) | El runner llama a Portainer para `stop` → reemplaza imagen/volumen → `start`. El artefacto se monta vía volumen Docker o se incluye en una imagen recreada. | Los containers están totalmente bajo Portainer y se pueden rebuilds/recreate por API |
-| **β. SSH + `docker pull && restart`** | El runner SSH al host, hace `docker pull` (si la imagen es la unidad) o `cp + docker restart` (si el artefacto es un archivo montado). | Hosts tienen Docker + acceso SSH desde el runner |
-| **γ. SCP + systemd** | El runner copia el JAR vía SCP, hace `systemctl restart <servicio>`. Sin Docker. | Servicios corren como units systemd directamente, sin containers |
+| **α. Portainer API** | stop → recreate via API (artefacto vía volumen Docker o rebuild de imagen) | Containers totalmente gestionados por Portainer |
+| **β. SSH + Docker** | runner SSH al host, `docker stop && cp && docker start` | Hosts tienen Docker + SSH abierto |
+| **γ. SCP + systemd** | runner SCP el JAR, `systemctl restart` | Services como units systemd, sin containers |
 
-**Importante**: v1 usa una **mezcla de α y β**: API de Portainer para start/stop + `cp` local del archivo (porque el agent corre en el host). El equivalente GA-native más cercano sería **β** (runner único, SSH al host, `docker stop && cp && docker start`) o **A+α** (runner único, todo via API de Portainer si el modelo de containers lo soporta).
+> **Pregunta**: ¿services todos containerizados? ¿JAR/WAR en volumen o dentro de la imagen?
 
-> **Pregunta para Soporte/IDS**: ¿los services corren todos containerizados via Portainer?
-> ¿El JAR/WAR se monta como volumen o está dentro de la imagen?
-> Si es volumen → β o "A+API+volumen". Si está en la imagen → α (rebuild via Portainer).
+### 5.3 Schema de `.github/deploy.json`
 
-### 2.3 Modelo de "instalaciones" — ¿dónde vive el config?
+Borrador (sujeto a refinar tras 5.1 y 5.2):
 
-Por el principio rector, v2 **no** lee `sistemas.json` de `BQN-UY/jenkins`. Necesita su propia fuente de verdad. Tres caminos:
+```json
+{
+  "environments": {
+    "testing":    { "installations": [ { "name": "...", "portainer_endpoint": "...", "portainer_container": "...", "deploy_path": "/opt/webapps", "target_name": "...", "auto_deploy": true } ] },
+    "staging":    { "installations": [ ... ] },
+    "production": { "installations": [ ... ] }
+  }
+}
+```
 
-| Opción | Implicancia |
-|---|---|
-| **A. `sistemas.json` en `BQN-UY/CI-CD`** | Single source para v2; el runner lo lee del mismo repo donde están los workflows (cero PATs cruzados). v1 sigue con su copia en `BQN-UY/jenkins` — divergen pero no se mezclan. Bueno si necesitamos vista global de instalaciones. |
-| **B. Config por proyecto** (`.github/deploy.json` o `.github/deploy.yml` en cada repo) | El repo dueño del servicio declara sus instalaciones. Descentralizado, cero registro central. Cada equipo gestiona el mapping de sus propios services. Pierde vista global pero ningún proyecto depende de otro. |
-| **C. GitHub Environments** + variables/secrets | Cada `environment` (testing/staging/production) en cada repo lleva sus `vars.PORTAINER_ENDPOINT`, `vars.DEPLOY_PATH`, `secrets.PORTAINER_TOKEN`, etc. Cero JSON, todo en GH UI. Native + auditado por GitHub. |
-
-**Recomendación inicial**: **B + C combinados**.
-- `.github/deploy.json` (o `.yml`) en cada repo → estructura: lista de instalaciones por environment, `portainer_endpoint`, `portainer_container`, `deploy_path`, `target_name`, `auto_deploy`. Versionado con el código.
-- GH Environments → secretos/tokens/URLs sensibles por ambiente. Required reviewers para production.
-
-Ventaja: ningún acoplamiento a un repo central, cero PATs cruzados, cada equipo dueño de su propio mapping. La vista global se obtiene a demanda con un script que escanee los repos via GitHub API (no es necesario tenerla pre-agregada).
+> **Pregunta**: ¿campos extra que faltan respecto a `sistemas.json` v1? ¿Algún proyecto tiene casos edge no cubiertos?
 
 ---
 
-## 3. Otras decisiones secundarias
-
-### 3.1 Aprobación de production
-- **GitHub Environments** ya provee aprobación manual (required reviewers). Mapea 1:1 al `input` de Jenkins.
-- **Pregunta**: ¿conservamos los submitters actuales (`admins,soporte,auxiliar_soporte`) como required reviewers en GH Environments?
-
-### 3.2 Notificaciones
-- v1 usa Google Chat. ¿Mantenemos? Alternativas: comentario en commit/PR, GitHub Discussions, Slack.
-- **Recomendación**: mantener Google Chat por continuidad.
-
-### 3.3 Registro de deploys
-- v1 escribe a un servicio interno (`deploy-registry`). Por el principio rector, v2 no lo invoca.
-- **Recomendación**: usar **GitHub Deployments API** (nativo) — cada deploy GA-native crea un Deployment en el repo del proyecto con env, ref y status. Auditable, queryable, sin servicio nuevo.
-- Si se requiere agregación entre repos, un dashboard externo puede leer la API de cada repo. Fuera de scope inicial.
-
-### 3.4 Resolución de URL en Nexus
-- v1 usa Nexus Search API (no asume el path) por dos razones: artifact ID con sufijo Scala `_2.13`, y timestamp Maven en snapshots.
-- **Decisión de Hito 1 + acp-api#8**: con `dynverSeparator := "-"` los paths son predecibles. ¿Sigue siendo necesaria la Search API o podemos asumir paths directos?
-
-### 3.5 Restore DB
-- v1 invoca `IDS/restoreDB`. ¿Migrar también a GA workflow_dispatch o queda fuera de Hito 2?
-- **Recomendación**: fuera de Hito 2; se aborda en su propio hito (parte de "operativos en GA" del informe Jenkins, §10 Fase 3).
-
----
-
-## 4. Criterios de aceptación del spec
+## 6. Criterios de aceptación del spec
 
 El spec se considera completo cuando responde:
 
-- [ ] (2.1) Cantidad y ubicación de runners GA + plan de instalación
-- [ ] (2.2) Mecanismo elegido (α/β/γ) + ejemplo end-to-end con un sistema real
-- [ ] (2.3) Ubicación de `sistemas.json` + schema actualizado si cambia
-- [ ] (3.1) Required reviewers de GH Environments definidos por env
-- [ ] (3.2) Notificaciones: canal y formato
-- [ ] (3.3) Registro de deploys: API y/o servicio
-- [ ] (3.4) Resolución de URL Nexus: directa vs Search API
-- [ ] Lista de secrets nuevos requeridos por el runner (Portainer, SSH keys, etc.)
-- [ ] Diseño del nuevo composite `shared/deploy-*` y reusable workflow `scala-api-deploy.yml`
-- [ ] Criterio de migración de proyectos: cómo se mueve un repo v2 publish-only a v2 con deploy GA-native (PR mecánico)
+- [ ] (5.1) Runner GA: cantidad, ubicación, plan de instalación
+- [ ] (5.2) Mecanismo de deploy elegido (α/β/γ) con ejemplo end-to-end
+- [ ] (5.3) Schema final de `.github/deploy.json`
+- [x] (4.x) Resto de decisiones tomadas
+- [ ] Lista de secrets/vars nuevos requeridos por el runner (Portainer token, SSH keys, etc.)
+- [ ] Diseño del composite `shared/deploy-*` y workflow `scala-api-deploy.yml`
+- [ ] Criterio de migración: cómo un repo v2 publish-only adopta el deploy GA-native (PR mecánico)
 
-Cuando el spec esté completo y aprobado → arranca Hito 3 (implementación).
+Cuando el spec esté completo → arranca Hito 3 (implementación).
 
 ---
 
-## 5. Próximos pasos
+## 7. Cambios al modelo v2 vigente que dispara este spec
 
-1. Compartir este borrador con Soporte/IDS para responder las preguntas de §2 y §3.
-2. Cuando estén las respuestas, actualizar este doc → consolidar en versión definitiva.
-3. Spinoff: PR en `BQN-UY/CI-CD` con el spec definitivo + ADR si corresponde.
-4. Habilitar Hito 3.
+Implementar este spec requiere cambios al CI-CD repo **antes** de tener el deploy GA-native:
+
+1. **Reescribir `scala-api-publish.yml`**: stop publishing to Nexus; create GH pre-release `v<NEXT>-snapshot.NNN` (develop) or `vX.Y.Z-rc.NNN` (release/hotfix) con JAR adjunto.
+2. **Modificar `scala-api-make-release.yml`**: stop publishing to Nexus; tag final + GH release + back-merge + bump `.github/next-bump` reset a `minor`.
+3. **Eliminar `scala-api-publish-rc.yml`** y su template (RCs son auto en push).
+4. **Crear `scala-api-cleanup-snapshots.yml`** (cron daily, conserva últimos 3 por target).
+5. **Crear reusable `update-next-bump.yml`** (stack-agnóstico, dispara en PR merged con label `breaking-change`).
+6. **Templates**: agregar `.github/next-bump` inicial, caller de cleanup, caller de update-next-bump.
+7. **Cada app que migre**: remover config Nexus de `build.sbt`, agregar `.github/next-bump`, actualizar callers.
+
+Estos cambios son **prerrequisito** del Hito 3 — sin ellos, los apps no tienen artefactos en GH Releases para que el deploy los consuma. Se ejecutan en su propio PR (no este).
+
+---
+
+## 8. Próximos pasos
+
+1. Compartir este spec con Soporte/IDS para responder §5.1, §5.2, §5.3.
+2. Cuando estén las respuestas → consolidar en este mismo PR.
+3. Mergear → habilita la ejecución de §7 y luego Hito 3.

--- a/docs/v2-hito2-deploy-spec.md
+++ b/docs/v2-hito2-deploy-spec.md
@@ -20,6 +20,27 @@ Documento canónico del diseño del deploy GA-native que reemplaza a Jenkins en 
 
 Este Hito 2 cubre **server apps**. Client apps y libs se documentan en sus propios specs/templates cuando corresponda.
 
+```mermaid
+flowchart LR
+    subgraph srv["Server apps (APIs, WARs, python servers)"]
+        S_repo[GitHub repo] -->|sbt package| S_release[GH Releases<br/>v*-snapshot.NNN<br/>v*-rc.NNN<br/>vX.Y.Z]
+        S_release -->|gh release download| S_deploy[Self-hosted runner GA<br/>+ Portainer API]
+        S_deploy --> S_target[Servicios en producción]
+    end
+    subgraph cli["Client apps (BPos, GPos, IDH)"]
+        C_repo[GitHub repo] -->|build| C_release[GH Releases<br/>vX.Y.Z]
+        C_release -->|download manual| C_install[Instalación en equipos externos]
+    end
+    subgraph libs["Libs (scala libs, protocolos)"]
+        L_repo[GitHub repo] -->|sbt publish| L_nexus[Nexus<br/>maven-snapshots<br/>maven-releases]
+        L_nexus -->|sbt resolve| L_consumer[Otros builds Scala]
+    end
+
+    style srv fill:#e3f2fd
+    style cli fill:#fff3e0
+    style libs fill:#f3e5f5
+```
+
 ---
 
 ## 2. Modelo de artefactos para server apps
@@ -46,6 +67,30 @@ Los apps **no publican a Nexus**. Cada artefacto generado por CI vive como adjun
 - **rc.NNN**: cada push a release/hotfix genera el siguiente RC automáticamente (no más `publish-rc` workflow_dispatch deliberado)
 - Los snapshots y RCs son **pre-releases** en GH; los finales son releases marcados `latest`
 
+```mermaid
+gitGraph
+    commit id: "v1.2.0" tag: "v1.2.0"
+    branch develop
+    checkout develop
+    commit id: "feat A" tag: "v1.3.0-snapshot.001"
+    commit id: "feat B" tag: "v1.3.0-snapshot.002"
+    commit id: "fix C"  tag: "v1.3.0-snapshot.003"
+    branch release/v1.3.0
+    checkout release/v1.3.0
+    commit id: "RC ready"  tag: "v1.3.0-rc.001"
+    commit id: "fix D"     tag: "v1.3.0-rc.002"
+    checkout main
+    merge release/v1.3.0 tag: "v1.3.0"
+    checkout develop
+    merge main
+    commit id: "feat E" tag: "v1.4.0-snapshot.001"
+```
+
+**Lectura del diagrama**:
+- Cada commit a develop genera un pre-release `v<NEXT>-snapshot.NNN`. NEXT se calcula con `last_final + bump` (acá `v1.2.0 + minor = v1.3.0`).
+- `start-release` corta la rama; cada push a `release/v1.3.0` genera `v1.3.0-rc.NNN`.
+- `make-release` crea el tag final `v1.3.0`, mergea a main y back-mergea a develop. El próximo push a develop arranca el ciclo de v1.4.0.
+
 ### 2.3 `.github/next-bump` — el bump del próximo release
 
 Archivo en cada repo app, contenido: `minor` (default) o `major`.
@@ -56,12 +101,53 @@ Archivo en cada repo app, contenido: `minor` (default) o `major`.
 
 **Edición manual permitida**: humanos pueden editar el archivo entre releases si la política cambió (p.ej., un breaking PR fue revertido y queremos volver a `minor`).
 
+```mermaid
+sequenceDiagram
+    actor Dev
+    participant PR as PR a develop
+    participant W as update-next-bump.yml
+    participant F as .github/next-bump
+    participant MR as make-release.yml
+    participant Tag as Git tag
+
+    Note over F: contenido inicial: "minor"
+
+    Dev->>PR: PR con label 'breaking-change'
+    PR->>W: trigger (PR closed=merged)
+    W->>F: leer
+    F-->>W: "minor"
+    W->>F: escribir "major" + commit
+    Note over F: ahora dice "major"
+
+    Dev->>MR: workflow_dispatch make-release
+    MR->>F: leer
+    F-->>MR: "major"
+    MR->>Tag: crear vX+1.0.0
+    MR->>F: reset a "minor" + commit
+    Note over F: vuelve a "minor" para el<br/>próximo ciclo
+```
+
 ### 2.4 Cleanup de snapshots
 
 Workflow `cleanup-snapshots.yml` (cron diario) por proyecto:
 - Conserva **últimos 3** pre-releases con tag `v*-snapshot.*` por target version
 - Borra el resto (pre-release + tag git asociado)
 - RCs y releases finales nunca se tocan
+
+```mermaid
+flowchart TD
+    cron["Cron diario"] --> list["Listar GH releases del repo"]
+    list --> filter["Filtrar por tag 'v*-snapshot.*'"]
+    filter --> group["Agrupar por target version<br/>(v1.3.0, v1.4.0, ...)"]
+    group --> sort["Por grupo: ordenar por NNN desc"]
+    sort --> keep["Top 3: conservar"]
+    sort --> drop["Resto: borrar release + tag"]
+    drop --> done["Log resumen"]
+    keep --> done
+
+    style keep fill:#c8e6c9
+    style drop fill:#ffcdd2
+```
 
 ### 2.5 Tag protection
 
@@ -212,8 +298,71 @@ Estos cambios son **prerrequisito** del Hito 3 — sin ellos, los apps no tienen
 
 ---
 
-## 8. Próximos pasos
+## 8. Visión end-to-end (Hito 3)
+
+Cómo se ve el flujo completo cuando todo esté implementado:
+
+```mermaid
+flowchart LR
+    subgraph dev["Push develop"]
+        D_push["Dev pushea a develop"] --> D_publish["scala-api-publish.yml"]
+        D_publish --> D_compute["Calcular target<br/>= last_final + bump<br/>+ next NNN"]
+        D_compute --> D_build["Build JAR"]
+        D_build --> D_release["GH pre-release<br/>v1.3.0-snapshot.NNN"]
+    end
+    subgraph rel["Push release/hotfix"]
+        R_push["Dev pushea a release/v1.3.0"] --> R_publish["scala-api-publish.yml"]
+        R_publish --> R_compute["Calcular siguiente rc.NNN"]
+        R_compute --> R_build["Build JAR"]
+        R_build --> R_release["GH pre-release<br/>v1.3.0-rc.NNN"]
+    end
+    subgraph mr["Make release manual"]
+        M_disp["Dev dispatches make-release"] --> M_tag["Tag vX.Y.Z + GH release final"]
+        M_tag --> M_back["Back-merge a develop"]
+        M_back --> M_reset["Reset .github/next-bump = minor"]
+    end
+    subgraph dep["Deploy GA-native (cualquiera de los anteriores)"]
+        D_release --> Dp_trigger["Trigger deploy a testing"]
+        R_release --> Dp_trigger2["Trigger deploy a staging"]
+        M_tag --> Dp_trigger3["Manual: Soporte deploy a production"]
+        Dp_trigger --> Dp_runner["Self-hosted runner GA"]
+        Dp_trigger2 --> Dp_runner
+        Dp_trigger3 --> Dp_runner
+        Dp_runner --> Dp_dl["gh release download <tag>"]
+        Dp_dl --> Dp_portainer["Portainer API:<br/>stop / cp / start"]
+        Dp_runner --> Dp_record["GH Deployments API:<br/>record env + ref + status"]
+        Dp_runner --> Dp_chat["Google Chat:<br/>notificar"]
+    end
+```
+
+---
+
+## 9. Próximos pasos
 
 1. Compartir este spec con Soporte/IDS para responder §5.1, §5.2, §5.3.
 2. Cuando estén las respuestas → consolidar en este mismo PR.
 3. Mergear → habilita la ejecución de §7 y luego Hito 3.
+
+---
+
+## 10. Navegación para AIs (Claude / Copilot)
+
+Documentos por jerarquía de autoridad:
+
+| Doc | Audiencia | Qué busca |
+|---|---|---|
+| **Este spec (`docs/v2-hito2-deploy-spec.md`)** | AIs + humanos | Modelo canónico de versionado y deploy v2 server apps. Si hay conflicto entre docs, **este gana**. |
+| `CLAUDE.md` (root) | AI Claude | Reglas operativas del repo: dónde modificar, dónde no, ambientes válidos. |
+| `templates/scala-api/CLAUDE.md` | AI Claude (proyectos) | Reglas para apps Scala individuales: branching, secrets, convenciones. |
+| `.github/copilot-instructions.md` (root y template) | AI Copilot | Versión condensada de las reglas. |
+| `docs/migration-v2.md` | Humanos | Catálogo de workflows + guía de migración. AIs lo consultan para detalle de un workflow específico. |
+| `docs/v2-sin-jenkins-roadmap.md` | Humanos + AIs | Hoja de ruta a Escenario C. AIs lo consultan para entender en qué hito está el trabajo. |
+| `docs/scala-migration-v2.md` | Humanos | Guía paso a paso para migrar un repo Scala existente. |
+
+**Cuando el usuario pide cambios sobre el modelo de versionado o deploy de server apps**: actualizar primero **este spec**, después cascadear a CLAUDE.md / copilot-instructions / templates.
+
+**Cuando el usuario pregunta "¿cómo versiona X?"**: consultar §2 de este spec.
+
+**Cuando el usuario pregunta "¿v2 usa Jenkins?"**: NO. Ver Principio rector + `docs/v2-sin-jenkins-roadmap.md`.
+
+**Cuando el usuario pregunta sobre libs**: este spec NO las cubre — siguen el modelo Maven-standard en Nexus. Cuando exista, ver `templates/scala-lib/`.

--- a/docs/v2-hito2-deploy-spec.md
+++ b/docs/v2-hito2-deploy-spec.md
@@ -1,0 +1,155 @@
+# Hito 2 — Spec del deploy GA-native (borrador)
+
+> Estado: **borrador para discusión** · Tracking: `docs/v2-sin-jenkins-roadmap.md` Hito 2
+
+Documento para alinear el diseño del workflow de deploy GA-native que reemplaza a Jenkins en v2.
+Contiene: requisitos heredados de v1, decisiones de diseño abiertas, y criterios de aceptación.
+
+## Principio rector
+
+**v2 no depende de `BQN-UY/jenkins` para nada.** Ese repo (incluyendo su rama `production`, los scripts groovy, `sistemas.json`, etc.) es legacy de v1 y queda congelado. v2 lee la lógica de v1 sólo como referencia para entender requisitos — pero ningún workflow ni runner GA invoca, importa o lee archivos de ese repo.
+
+---
+
+## 1. Baseline — qué hace el deploy v1 (Jenkins)
+
+Resumen de `~/projects/bqn/jenkins/CI_CD/deploy-nexus.groovy` (319 líneas, pipeline declarativo).
+**Esta sección es descriptiva** — captura qué requisitos hay que cubrir en v2. v2 NO lee, ejecuta, ni invoca código del repo `BQN-UY/jenkins` (ver Principio rector).
+
+**Inputs** (por webhook GWT desde GitHub Actions):
+- `SISTEMA` — nombre del sistema, debe coincidir con `sistemas.json`
+- `VERSION` — sbt-dynver (snapshot o release) o tag explícito
+- `ENVIRONMENT` — `testing` | `staging` | `production`
+- `ACTOR` — github actor que disparó el deploy
+- `INSTALLATION` — coma-separado, vacío = todas las que tengan `auto_deploy: true`
+- `RESTORE` — bool, restaurar DB antes (solo testing/staging)
+
+**Flujo:**
+1. Carga `sistemas.json` desde `BQN-UY/jenkins/config/sistemas.json` (PAT GitHub).
+2. Resuelve `installations` para el `(sistema, environment)` solicitado.
+3. Notifica inicio a Google Chat (webhook).
+4. Si production → `input` manual con submitter restringido (`admins,soporte,auxiliar_soporte`).
+5. Si `RESTORE` y no production → invoca `IDS/restoreDB`.
+6. **Por cada instalación, en paralelo:**
+   - Resuelve URL exacta del artefacto en Nexus vía Search API (necesario por el sufijo Scala `_2.13` y el timestamp Maven en snapshots).
+   - Se conecta al **endpoint Portainer** correspondiente (cada instalación tiene su `portainer_endpoint` y `portainer_container`).
+   - Stop container.
+   - Descarga JAR/WAR desde Nexus a `localFile`.
+   - Copia a `deploy_path/target_name` (default `/opt/webapps`).
+   - Start container.
+7. Registra el deploy en `deploy-registry` (success/failure por instalación).
+8. Notifica fin a Google Chat.
+
+**Dependencias técnicas:**
+- Portainer API (token `portainer_jenkins_token`).
+- Nexus (credenciales `nexus_deploy`).
+- `sistemas.json` con schema: `apps[].environments[].installations[]` con `name`, `portainer_endpoint`, `portainer_container`, `artifact.{extension, deploy_path, target_name}`, `auto_deploy`.
+- Google Chat webhook por ambiente.
+- Jenkins agents en cada `portainer_endpoint` (el `cp` corre **localmente en el host destino**, no remoto — por eso se usa `node(pEndpoint)`).
+- `deploy-registry` (servicio interno).
+- `IDS/restoreDB` (job Jenkins separado).
+
+---
+
+## 2. Decisiones de diseño abiertas
+
+### 2.1 Self-hosted runner GA — ¿dónde y cuántos?
+
+El runner GA reemplaza al "Jenkins agent" del modelo v1. Necesita:
+- Acceso de red a Portainer (todos los endpoints), Nexus, NAS2, DBs.
+- Capacidad de ejecutar `curl` + `cp` (mínimo).
+- Token efímero a GitHub (auto-gestionado por el runner).
+
+| Opción | Pros | Contras |
+|---|---|---|
+| **A. Un runner único** en `DEPLOY_IP` | Mínimo a operar; ya está en red interna (acceso a todo) | SPOF; el `cp` al host destino debe ser **remoto** (SSH), no local — distinto al modelo v1 |
+| **B. Un runner por endpoint Portainer** (espejo de Jenkins agents) | `cp` local al host (igual que v1); paraleliza naturalmente | N runners a instalar/mantener (~5-10); más superficie de ataque |
+| **C. Runners "labeled"** (subset estratégico, ej. uno por DC físico) | Equilibrio: paralelismo + menos superficie | Diseñar el labeling y el routing del job; complejidad media |
+
+> **Pregunta para Soporte/IDS**: ¿cuántos `portainer_endpoint` distintos hay hoy en `sistemas.json`?
+> ¿Están en el mismo DC? Si sí, A simplifica mucho. Si están distribuidos geográficamente, C es la respuesta natural.
+
+### 2.2 Mecanismo de deploy — ¿cómo llegamos al artefacto en el container?
+
+Tres caminos limpios:
+
+| Opción | Cómo funciona | Encaja si |
+|---|---|---|
+| **α. Portainer API** (HTTP + token) | El runner llama a Portainer para `stop` → reemplaza imagen/volumen → `start`. El artefacto se monta vía volumen Docker o se incluye en una imagen recreada. | Los containers están totalmente bajo Portainer y se pueden rebuilds/recreate por API |
+| **β. SSH + `docker pull && restart`** | El runner SSH al host, hace `docker pull` (si la imagen es la unidad) o `cp + docker restart` (si el artefacto es un archivo montado). | Hosts tienen Docker + acceso SSH desde el runner |
+| **γ. SCP + systemd** | El runner copia el JAR vía SCP, hace `systemctl restart <servicio>`. Sin Docker. | Servicios corren como units systemd directamente, sin containers |
+
+**Importante**: v1 usa una **mezcla de α y β**: API de Portainer para start/stop + `cp` local del archivo (porque el agent corre en el host). El equivalente GA-native más cercano sería **β** (runner único, SSH al host, `docker stop && cp && docker start`) o **A+α** (runner único, todo via API de Portainer si el modelo de containers lo soporta).
+
+> **Pregunta para Soporte/IDS**: ¿los services corren todos containerizados via Portainer?
+> ¿El JAR/WAR se monta como volumen o está dentro de la imagen?
+> Si es volumen → β o "A+API+volumen". Si está en la imagen → α (rebuild via Portainer).
+
+### 2.3 Modelo de "instalaciones" — ¿dónde vive el config?
+
+Por el principio rector, v2 **no** lee `sistemas.json` de `BQN-UY/jenkins`. Necesita su propia fuente de verdad. Tres caminos:
+
+| Opción | Implicancia |
+|---|---|
+| **A. `sistemas.json` en `BQN-UY/CI-CD`** | Single source para v2; el runner lo lee del mismo repo donde están los workflows (cero PATs cruzados). v1 sigue con su copia en `BQN-UY/jenkins` — divergen pero no se mezclan. Bueno si necesitamos vista global de instalaciones. |
+| **B. Config por proyecto** (`.github/deploy.json` o `.github/deploy.yml` en cada repo) | El repo dueño del servicio declara sus instalaciones. Descentralizado, cero registro central. Cada equipo gestiona el mapping de sus propios services. Pierde vista global pero ningún proyecto depende de otro. |
+| **C. GitHub Environments** + variables/secrets | Cada `environment` (testing/staging/production) en cada repo lleva sus `vars.PORTAINER_ENDPOINT`, `vars.DEPLOY_PATH`, `secrets.PORTAINER_TOKEN`, etc. Cero JSON, todo en GH UI. Native + auditado por GitHub. |
+
+**Recomendación inicial**: **B + C combinados**.
+- `.github/deploy.json` (o `.yml`) en cada repo → estructura: lista de instalaciones por environment, `portainer_endpoint`, `portainer_container`, `deploy_path`, `target_name`, `auto_deploy`. Versionado con el código.
+- GH Environments → secretos/tokens/URLs sensibles por ambiente. Required reviewers para production.
+
+Ventaja: ningún acoplamiento a un repo central, cero PATs cruzados, cada equipo dueño de su propio mapping. La vista global se obtiene a demanda con un script que escanee los repos via GitHub API (no es necesario tenerla pre-agregada).
+
+---
+
+## 3. Otras decisiones secundarias
+
+### 3.1 Aprobación de production
+- **GitHub Environments** ya provee aprobación manual (required reviewers). Mapea 1:1 al `input` de Jenkins.
+- **Pregunta**: ¿conservamos los submitters actuales (`admins,soporte,auxiliar_soporte`) como required reviewers en GH Environments?
+
+### 3.2 Notificaciones
+- v1 usa Google Chat. ¿Mantenemos? Alternativas: comentario en commit/PR, GitHub Discussions, Slack.
+- **Recomendación**: mantener Google Chat por continuidad.
+
+### 3.3 Registro de deploys
+- v1 escribe a un servicio interno (`deploy-registry`). Por el principio rector, v2 no lo invoca.
+- **Recomendación**: usar **GitHub Deployments API** (nativo) — cada deploy GA-native crea un Deployment en el repo del proyecto con env, ref y status. Auditable, queryable, sin servicio nuevo.
+- Si se requiere agregación entre repos, un dashboard externo puede leer la API de cada repo. Fuera de scope inicial.
+
+### 3.4 Resolución de URL en Nexus
+- v1 usa Nexus Search API (no asume el path) por dos razones: artifact ID con sufijo Scala `_2.13`, y timestamp Maven en snapshots.
+- **Decisión de Hito 1 + acp-api#8**: con `dynverSeparator := "-"` los paths son predecibles. ¿Sigue siendo necesaria la Search API o podemos asumir paths directos?
+
+### 3.5 Restore DB
+- v1 invoca `IDS/restoreDB`. ¿Migrar también a GA workflow_dispatch o queda fuera de Hito 2?
+- **Recomendación**: fuera de Hito 2; se aborda en su propio hito (parte de "operativos en GA" del informe Jenkins, §10 Fase 3).
+
+---
+
+## 4. Criterios de aceptación del spec
+
+El spec se considera completo cuando responde:
+
+- [ ] (2.1) Cantidad y ubicación de runners GA + plan de instalación
+- [ ] (2.2) Mecanismo elegido (α/β/γ) + ejemplo end-to-end con un sistema real
+- [ ] (2.3) Ubicación de `sistemas.json` + schema actualizado si cambia
+- [ ] (3.1) Required reviewers de GH Environments definidos por env
+- [ ] (3.2) Notificaciones: canal y formato
+- [ ] (3.3) Registro de deploys: API y/o servicio
+- [ ] (3.4) Resolución de URL Nexus: directa vs Search API
+- [ ] Lista de secrets nuevos requeridos por el runner (Portainer, SSH keys, etc.)
+- [ ] Diseño del nuevo composite `shared/deploy-*` y reusable workflow `scala-api-deploy.yml`
+- [ ] Criterio de migración de proyectos: cómo se mueve un repo v2 publish-only a v2 con deploy GA-native (PR mecánico)
+
+Cuando el spec esté completo y aprobado → arranca Hito 3 (implementación).
+
+---
+
+## 5. Próximos pasos
+
+1. Compartir este borrador con Soporte/IDS para responder las preguntas de §2 y §3.
+2. Cuando estén las respuestas, actualizar este doc → consolidar en versión definitiva.
+3. Spinoff: PR en `BQN-UY/CI-CD` con el spec definitivo + ADR si corresponde.
+4. Habilitar Hito 3.

--- a/templates/scala-api/.github/copilot-instructions.md
+++ b/templates/scala-api/.github/copilot-instructions.md
@@ -1,9 +1,14 @@
 # Copilot instructions — Scala API (CI/CD v2)
 
+> **Doc canónico**: `BQN-UY/CI-CD/docs/v2-hito2-deploy-spec.md`. Si hay conflicto, ese gana.
+
 ## CI/CD
 
-Este proyecto usa CI/CD v2 de BQN-UY. No agregar lógica de build o deploy
-directamente en los workflows — todo se delega a actions de `BQN-UY/CI-CD`.
+Este proyecto usa CI/CD v2 de BQN-UY. No agregar lógica de build o deploy directamente en los workflows — todo se delega a actions de `BQN-UY/CI-CD`.
+
+## Tipo de proyecto
+
+**Server app** — los artefactos van a **GitHub Releases** del propio repo (NO a Nexus). Cada build crea un Release/Pre-release con el JAR adjunto.
 
 ## Branching model
 
@@ -33,38 +38,37 @@ directamente en los workflows — todo se delega a actions de `BQN-UY/CI-CD`.
 - Fixes durante un release → `fix/*` desde `release/vX.Y.Z`, PR hacia `release/vX.Y.Z`, NUNCA hacia `develop`
 - `dependabot/*` y `scala-steward/*` apuntan siempre a `develop` — nunca a `release/**` ni `hotfix/**`
 - `hotfix/**` = exclusivo para fixes de la versión en producción
-- `deploy-action` = el PR requiere acción manual en infra antes/durante el deploy (nueva env var, migración DB, nuevo secret, nuevo componente). Reemplaza al label de tipo — describir el cambio en el cuerpo del PR
+- `breaking-change` label: marca que el próximo release necesita major bump (workflow lo registra en `.github/next-bump`)
+- `deploy-action` = el PR requiere acción manual en infra antes/durante el deploy. Reemplaza al label de tipo — describir en cuerpo del PR.
 
-## Ambientes
+## Versionado
 
-| Rama | Ambiente |
-|---|---|
-| `develop`, `release/**` | testing |
-| `hotfix/**` | staging |
-| `make-release` | production |
+| Trigger | Tag GH | Tipo | Ambiente del deploy |
+|---|---|---|---|
+| push `develop` | `v<NEXT>-snapshot.NNN` | pre-release | testing |
+| push `release/vX.Y.Z` | `vX.Y.Z-rc.NNN` | pre-release | staging |
+| push `hotfix/vX.Y.Z-desc` | `vX.Y.Z-rc.NNN` | pre-release | staging |
+| `make-release` (manual) | `vX.Y.Z` | release final | production (manual) |
 
-## Secrets y variables de deploy
+- NNN: 3 dígitos zero-padded, auto-incrementa
+- `<NEXT>` = `last_final_tag + bump`, donde `bump` viene de `.github/next-bump` (default `minor`, cambia a `major` en PR con label `breaking-change`)
 
-```
-# Org-level (BQN-UY) — no configurar por repo
-JENKINS_DEPLOY_URL              # URL base del webhook GWT
-JENKINS_DEPLOY_TESTING_TOKEN    # token → rutea a deploy-nexus-testing
-JENKINS_DEPLOY_STAGING_TOKEN    # token → rutea a deploy-nexus-staging
-JENKINS_DEPLOY_PRODUCTION_TOKEN # token → rutea a deploy-nexus-production
+## Tag protection (configurar en GH Settings)
 
-# Repo-level variable
-vars.SISTEMA   # nombre del servicio (ej. payments-api)
-```
+- `v[0-9]*` → protegido (releases finales inmutables)
+- `v*-rc.*` → protegido (RCs auditados inmutables)
+- `v*-snapshot.*` → libre (cleanup workflow borra)
 
-## Secrets de Nexus
+## Secrets
 
-```
-NEXUS_USER / NEXUS_PASSWORD / NEXUS_URL
-```
+Para server apps no se requieren secrets especiales — el `GITHUB_TOKEN` que GitHub provee automáticamente alcanza para publish y deploy GA-native (cuando exista).
 
 ## Qué NO hacer
 
-- No modificar la lógica interna de los workflows en `.github/workflows/`
-- No usar nombres de secrets distintos a los documentados
+- No modificar la lógica interna de los workflows en `.github/workflows/` — son callers cortos al reusable
+- No publicar a Nexus desde este repo (server apps van a GH Releases)
+- No declarar `dynverSeparator` ni `dynverSonatypeSnapshots` en `build.sbt` (son para libs)
+- No usar secrets `JENKINS_DEPLOY_*` ni `NEXUS_*` (no aplican en v2 server apps)
 - No commitear fixes de release en `develop`
 - No ejecutar `make-release` sin haber validado en testing primero
+- No borrar tags `v[0-9]*` ni `v*-rc.*`

--- a/templates/scala-api/CLAUDE.md
+++ b/templates/scala-api/CLAUDE.md
@@ -40,16 +40,54 @@ hay que ajustar inputs o triggers específicos del proyecto.
 | `hotfix/vX.Y.Z-desc` | `main` via `start-hotfix` | `make-release` → `main` | Fix urgente a producción |
 | `main` | — | — | Producción |
 
-## Semántica de Nexus por rama
+## Storage y versionado de artefactos
 
-| Rama | Nexus | Propósito |
+> **Importante**: este proyecto es un **server app** — los artefactos NO van a Nexus. Cada build genera un GitHub Release/Pre-release del propio repo con el JAR adjunto. (Las libs sí van a Nexus; ver `BQN-UY/CI-CD/docs/v2-hito2-deploy-spec.md` §1.)
+
+| Trigger | Tag GH | Tipo | Cleanup | Ambiente del deploy |
+|---|---|---|---|---|
+| push `develop` | `v<NEXT>-snapshot.NNN` | pre-release | sí (workflow daily, conserva últimos 3 por target) | testing |
+| push `release/vX.Y.Z` | `vX.Y.Z-rc.NNN` | pre-release | no | staging |
+| push `hotfix/vX.Y.Z-desc` | `vX.Y.Z-rc.NNN` | pre-release | no | staging |
+| `make-release` (manual) | `vX.Y.Z` | release final | no | production (manual por Soporte) |
+
+- **NNN**: 3 dígitos zero-padded (`001`, `002`, ...), auto-incrementa por trigger
+- **`<NEXT>`**: versión target para develop, calculada como `last_final_tag + bump` donde `bump` se lee de `.github/next-bump`
+- RCs son auto en cada push a release/hotfix — no hay workflow_dispatch manual para crear RC
+
+```mermaid
+gitGraph
+    commit id: "v1.2.0" tag: "v1.2.0"
+    branch develop
+    checkout develop
+    commit id: "feat A" tag: "v1.3.0-snapshot.001"
+    commit id: "feat B" tag: "v1.3.0-snapshot.002"
+    branch release/v1.3.0
+    checkout release/v1.3.0
+    commit id: "RC" tag: "v1.3.0-rc.001"
+    commit id: "fix" tag: "v1.3.0-rc.002"
+    checkout main
+    merge release/v1.3.0 tag: "v1.3.0"
+    checkout develop
+    merge main
+    commit id: "feat C" tag: "v1.4.0-snapshot.001"
+```
+
+## `.github/next-bump`
+
+Archivo en este repo, contenido: `minor` (default) o `major`.
+
+- Cuando se mergea un PR a `develop` con label `breaking-change`, el workflow `update-next-bump.yml` lo cambia a `major` (commit + push).
+- `make-release.yml` lo lee, aplica el bump al último final tag para calcular el target del release, y lo resetea a `minor` para el próximo ciclo.
+- Edición manual permitida si la política cambió (ej. un breaking PR fue revertido).
+
+## Tag protection (configurar en GH Settings → Tag protection rules)
+
+| Patrón | Protegido contra | Razón |
 |---|---|---|
-| `develop` | snapshots | Features de la próxima versión |
-| `release/**` | snapshots + RC tags | Fixes del release en curso; cada `publish-rc` crea `vX.Y.Z-rc.N` |
-| `hotfix/**` | snapshots + RC tags | Fix urgente; mismo modelo de RCs |
-| `make-release` | **releases** (`vX.Y.Z`) | Versión final e irreversible |
-
-> **Deploy a ambientes**: en v2 actual, los workflows publican el JAR a Nexus pero **no deployan**. La asociación rama→ambiente (testing/staging/production) y el push a infraestructura se hará vía workflow GA-native cuando esté implementado (ver `docs/v2-sin-jenkins-roadmap.md`, Hito 3).
+| `v[0-9]*` | delete + force-push | releases finales son inmutables |
+| `v*-rc.*` | delete + force-push | RCs auditados son inmutables |
+| `v*-snapshot.*` | (libre) | cleanup workflow necesita borrarlos |
 
 ## Reglas críticas
 
@@ -68,21 +106,27 @@ hay que ajustar inputs o triggers específicos del proyecto.
 | Archivo | Trigger | Qué hace |
 |---|---|---|
 | `ci.yml` | PR → develop · push release/\*\* · push hotfix/\*\* | lint + build + security |
-| `publish.yml` | push develop · push release/\*\* · push hotfix/\*\* | snapshot Nexus (sin deploy automático — ver `docs/v2-sin-jenkins-roadmap.md`) |
-| `start-release.yml` | manual (workflow_dispatch) | crea `release/vX.Y.Z` desde develop |
-| `make-release.yml` | manual (workflow_dispatch) | tag + Nexus release + GitHub Release + back-merge (sin deploy production — ver `docs/v2-sin-jenkins-roadmap.md`) |
+| `publish.yml` | push develop · push release/\*\* · push hotfix/\*\* | build JAR + GH pre-release con tag `v*-snapshot.NNN` o `v*-rc.NNN` |
+| `start-release.yml` | manual (workflow_dispatch) | crea `release/vX.Y.Z` desde develop (versión leída de `.github/next-bump`) |
+| `make-release.yml` | manual (workflow_dispatch) | tag final `vX.Y.Z` + GH release + back-merge a develop + reset `.github/next-bump` |
 | `start-hotfix.yml` | manual (workflow_dispatch) | crea `hotfix/vX.Y.Z-desc` desde main |
+| `cleanup-snapshots.yml` | cron daily | borra pre-releases `v*-snapshot.*` viejos (conserva últimos 3 por target) |
+| `update-next-bump.yml` | PR closed (merged) en develop | si el PR tiene label `breaking-change`, setea `.github/next-bump` a `major` |
 | `setup-labels.yml` | manual (workflow_dispatch) | crea/sincroniza las labels estándar (tipo + `size/*`) — correr al inicializar el repo |
 
 > Las labels `size/xs..xl` son informativas y las asigna automáticamente `pr-size-label` en cada PR según líneas y archivos modificados. No reemplazan al label de tipo — `label-check` sigue exigiendo exactamente una de `feature` / `fix` / `chore` / `update` / `deploy-action` / `breaking-change`.
 
-## Secrets y variables requeridos
+## Secrets y variables
+
+Para server apps (este proyecto) **no se requieren secrets de Nexus** — los artefactos van a GH Releases. Auth nativa con `${{ secrets.GITHUB_TOKEN }}`, auto-provisto por GitHub.
 
 | Secret / Variable | Nivel | Uso |
 |---|---|---|
-| `NEXUS_USER` / `NEXUS_PASSWORD` / `NEXUS_URL` | repo | Publicar JAR en Nexus |
+| (ninguno explícito) | — | Build + publish a GH Releases solo necesitan el `GITHUB_TOKEN` que GitHub provee automáticamente |
 
-> **Nota**: en v2 los secrets `JENKINS_DEPLOY_*` y `vars.SISTEMA` ya no aplican — el deploy quedó fuera del scope de los reusable workflows (ver `docs/v2-sin-jenkins-roadmap.md`). Volverán cuando el deploy GA-native esté implementado (Hito 3) o serán reemplazados por nuevos secrets según el mecanismo elegido.
+Cuando el deploy GA-native esté listo (Hito 3, ver `docs/v2-hito2-deploy-spec.md`), se agregarán secrets para Portainer / SSH según el mecanismo elegido.
+
+> Los secrets `NEXUS_*`, `JENKINS_DEPLOY_*` y `vars.SISTEMA` que aparecen en proyectos v1 **NO aplican** a server apps en v2. Si están configurados en el repo, se pueden ignorar/eliminar tras la migración.
 
 ## Convención de configuración
 
@@ -163,3 +207,7 @@ La URL local queda activa por defecto; la URL de testing se comenta con `#` para
 - No usar nombres de secrets distintos a los documentados arriba
 - No modificar el branching model — `develop` nunca mergea directo a `main`
 - No commitear en `develop` para resolver un issue de un release en curso
+- **No publicar a Nexus desde este repo** — server apps en v2 publican a GH Releases. Si `build.sbt` tiene `publishTo` apuntando a Nexus, removerlo en la migración.
+- **No declarar `dynverSeparator` ni `dynverSonatypeSnapshots`** en `build.sbt` — son settings para libs (Maven), no para apps. La versión la calcula el workflow y se pasa como tag GH.
+- **No invocar `jenkins-deploy-trigger`** ni usar secrets `JENKINS_DEPLOY_*` — v2 server apps no dependen de Jenkins (ver `BQN-UY/CI-CD/docs/v2-sin-jenkins-roadmap.md`).
+- **No borrar tags `v[0-9]*` ni `v*-rc.*`** — están protegidos por convención (configurar tag protection en GH Settings).


### PR DESCRIPTION
## Summary
Borrador del spec para el deploy GA-native (Hito 2 de `docs/v2-sin-jenkins-roadmap.md`). No se mergea hasta que las preguntas abiertas estén respondidas con Soporte/IDS — vive como WIP en este PR.

## Principio rector
**v2 no depende de `BQN-UY/jenkins` para nada.** Ese repo (rama `production`, scripts groovy, `sistemas.json`) queda congelado como legacy v1. v2 lee su lógica sólo como referencia descriptiva, sin invocar, importar ni leer archivos del repo.

## Decisiones tomadas (recomendaciones del spec)

| § | Tema | Decisión |
|---|---|---|
| 2.3 | Modelo de instalaciones | **B+C combinados**: `.github/deploy.json` por repo + GitHub Environments para secrets/URLs. Cero acoplamiento a un repo central, cero PATs cruzados. Descartada la opción de leer `sistemas.json` desde `BQN-UY/jenkins`. |
| 3.1 | Aprobación production | GitHub Environments `required reviewers` (mapea 1:1 al `input` de Jenkins). |
| 3.2 | Notificaciones | Mantener Google Chat por continuidad con Soporte. |
| 3.3 | Registro de deploys | **GitHub Deployments API** (nativo). Sin servicio nuevo. Auditable y queryable por repo. |
| 3.5 | Restore DB | Fuera de scope Hito 2 (se aborda con migración de operativos en su propio hito). |

## Decisiones abiertas (input de Soporte/IDS)

| § | Pregunta |
|---|---|
| 2.1 | Cantidad/ubicación de self-hosted runners GA (A: uno único / B: uno por endpoint / C: subset labeled). Depende de cuántos endpoints Portainer hay y cómo están distribuidos. |
| 2.2 | Mecanismo de deploy: Portainer API (α) / SSH+`docker pull && restart` (β) / SCP+systemd (γ). Depende de cómo corren los services hoy (containers vs systemd, JAR montado vs en imagen). |
| 3.4 | Resolución de URL Nexus: directa (asumiendo paths predecibles tras `dynverSeparator := "-"`) vs Search API (como hace v1). |

## Próximos pasos
1. Compartir este PR con Soporte/IDS para responder §2.1, §2.2, §3.4
2. Actualizar el doc con respuestas → versión definitiva en este mismo PR
3. Mergear → habilita Hito 3 (implementación)