### PR TITLE
fix: NEXUS_USER/PASSWORD env para resolver deps en publish y make-release

### DIFF
--- a/.github/workflows/scala-api-make-release.yml
+++ b/.github/workflows/scala-api-make-release.yml
@@ -33,6 +33,10 @@ jobs:
       security-events: write      # upload de SARIF al tab de Security
     env:
       TZ: America/Montevideo
+      # sbt resuelve dependencias desde el Nexus privado BQN.
+      # NO publicamos a Nexus pero sí descargamos libs internas.
+      NEXUS_USER:     ${{ secrets.NEXUS_USER }}
+      NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/scala-api-publish.yml
+++ b/.github/workflows/scala-api-publish.yml
@@ -35,6 +35,10 @@ jobs:
       contents: write             # crear tag y release
     env:
       TZ: America/Montevideo
+      # sbt resuelve dependencias desde el Nexus privado BQN.
+      # NO publicamos a Nexus pero sí descargamos libs internas.
+      NEXUS_USER:     ${{ secrets.NEXUS_USER }}
+      NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/templates/scala-api/.github/copilot-instructions.md
+++ b/templates/scala-api/.github/copilot-instructions.md
@@ -61,7 +61,8 @@ Este proyecto usa CI/CD v2 de BQN-UY. No agregar lógica de build o deploy direc
 
 ## Secrets
 
-Para server apps no se requieren secrets especiales — el `GITHUB_TOKEN` que GitHub provee automáticamente alcanza para publish y deploy GA-native (cuando exista).
+- `NEXUS_USER` / `NEXUS_PASSWORD` (repo): **resolver** libs internas desde Nexus BQN. NO se usan para publicar — apps publican a GH Releases.
+- `GITHUB_TOKEN`: auto-provisto. Crear tags, releases, deployments.
 
 ## Qué NO hacer
 

--- a/templates/scala-api/CLAUDE.md
+++ b/templates/scala-api/CLAUDE.md
@@ -118,15 +118,14 @@ Archivo en este repo, contenido: `minor` (default) o `major`.
 
 ## Secrets y variables
 
-Para server apps (este proyecto) **no se requieren secrets de Nexus** — los artefactos van a GH Releases. Auth nativa con `${{ secrets.GITHUB_TOKEN }}`, auto-provisto por GitHub.
-
 | Secret / Variable | Nivel | Uso |
 |---|---|---|
-| (ninguno explícito) | — | Build + publish a GH Releases solo necesitan el `GITHUB_TOKEN` que GitHub provee automáticamente |
+| `NEXUS_USER` / `NEXUS_PASSWORD` | repo | **Resolver** dependencias desde el Nexus privado BQN (sbt resolve). NO se usan para publicar — server apps publican a GH Releases. |
+| `GITHUB_TOKEN` | auto-provisto | Crear tags, releases, deployments en el propio repo |
 
-Cuando el deploy GA-native esté listo (Hito 3, ver `docs/v2-hito2-deploy-spec.md`), se agregarán secrets para Portainer / SSH según el mecanismo elegido.
-
-> Los secrets `NEXUS_*`, `JENKINS_DEPLOY_*` y `vars.SISTEMA` que aparecen en proyectos v1 **NO aplican** a server apps en v2. Si están configurados en el repo, se pueden ignorar/eliminar tras la migración.
+- `NEXUS_URL` ya **no se requiere** (antes era para `publishTo`, que ya no se usa).
+- Cuando el deploy GA-native esté listo (Hito 3, ver `docs/v2-hito2-deploy-spec.md`), se agregarán secrets para Portainer / SSH según el mecanismo elegido.
+- Los secrets `JENKINS_DEPLOY_*` y `vars.SISTEMA` que aparecen en proyectos v1 **NO aplican** a server apps en v2. Si están configurados en el repo, se pueden eliminar tras la migración.
 
 ## Convención de configuración
 


### PR DESCRIPTION
Los server apps v2 NO publican a Nexus pero sí RESOLVEN libs internas desde Nexus privado. sbt necesita las credenciales durante `compile`/`assembly`/`test`.

Detectado al preparar la migración de acp-api: sin `NEXUS_USER`/`NEXUS_PASSWORD` en el job env, `sbt assembly` falla al descargar libs `com.bqn:fui`, `com.bqn:bsecurity-client`, etc.