### PR TITLE
feat(scala-lib): reusable workflows v2 (CI + publish-snapshot + make-release)

### DIFF
--- a/.github/workflows/scala-lib-ci.yml
+++ b/.github/workflows/scala-lib-ci.yml
@@ -1,0 +1,82 @@
+name: Scala Lib · CI (reusable)
+
+# Reusable workflow v2 — invocar desde el repo cliente con:
+#
+#   jobs:
+#     ci:
+#       uses: BQN-UY/CI-CD/.github/workflows/scala-lib-ci.yml@v2
+#       secrets: inherit
+
+on:
+  workflow_call:
+    inputs:
+      java-version:
+        description: Versión de Java para sbt
+        required: false
+        type: string
+        default: "21"
+
+jobs:
+  auto-label:
+    name: Auto-label PR
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: BQN-UY/CI-CD/.github/actions/shared/auto-label@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  label-check:
+    name: Verificar label de PR
+    needs: auto-label
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: BQN-UY/CI-CD/.github/actions/shared/label-check@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  pr-size-label:
+    name: Etiquetar tamaño de PR
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: BQN-UY/CI-CD/.github/actions/shared/pr-size-label@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  lint-build:
+    name: Lint & Build
+    runs-on: ubuntu-latest
+    env:
+      TZ: America/Montevideo
+      NEXUS_USER: ${{ secrets.NEXUS_USER }}
+      NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0          # sbt-dynver necesita historial Git completo
+      - uses: BQN-UY/CI-CD/.github/actions/backend/scala/lint-build@v2
+        with:
+          java-version: ${{ inputs.java-version }}
+
+  security:
+    name: Security scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write    # requerido para subir SARIF al tab de Security
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0          # detect-secrets analiza historial completo
+      - uses: BQN-UY/CI-CD/.github/actions/shared/security-scan@v2

--- a/.github/workflows/scala-lib-make-release.yml
+++ b/.github/workflows/scala-lib-make-release.yml
@@ -1,0 +1,121 @@
+name: Scala Lib · Make release (reusable)
+
+# Reusable workflow v2 — invocar desde el repo cliente con:
+#
+#   on:
+#     workflow_dispatch:
+#       inputs:
+#         version:
+#           description: "Versión final X.Y.Z (sin prefijo v)"
+#           required: true
+#           type: string
+#   jobs:
+#     make-release:
+#       uses: BQN-UY/CI-CD/.github/workflows/scala-lib-make-release.yml@v2
+#       with:
+#         version: ${{ inputs.version }}
+#       secrets: inherit
+#
+# Tag final `vX.Y.Z` sobre la rama desde la cual se dispara el workflow
+# (típicamente `develop`) → sbt publish a Nexus maven-releases con versión
+# `X.Y.Z` (sin -SNAPSHOT, derivada de sbt-dynver al detectar tag clean).
+# Crea GH Release para trazabilidad. NO usa branches release/hotfix —
+# las libs no requieren stabilización en ambiente.
+#
+# Requiere en build.sbt:
+#   - publishTo := releases → Nexus maven-releases  (cuando NO es snapshot)
+#   - dynverSeparator        := "-"
+#   - dynverSonatypeSnapshots := true
+#   - crossPaths             := true   (default; conservar para libs)
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Versión final X.Y.Z (sin prefijo v)"
+        required: true
+        type: string
+      java-version:
+        description: Versión de Java para sbt
+        required: false
+        type: string
+        default: "21"
+
+jobs:
+  make-release:
+    name: Tag + sbt publish → Nexus maven-releases
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write             # crear tag y GH Release
+    env:
+      TZ: America/Montevideo
+      NEXUS_USER:     ${{ secrets.NEXUS_USER }}
+      NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0          # sbt-dynver necesita historial Git completo
+
+      - name: Validar formato de versión
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: version debe tener formato X.Y.Z (recibido: '$VERSION')" >&2
+            exit 1
+          fi
+
+      - name: Validar que el tag no exista y sea estrictamente mayor
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          git fetch --tags --prune
+
+          if git rev-parse --verify "refs/tags/v$VERSION" >/dev/null 2>&1; then
+            echo "Error: el tag v$VERSION ya existe" >&2
+            exit 1
+          fi
+
+          LAST=$(git tag --list 'v[0-9]*' --sort=-version:refname \
+                  | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
+          if [ -n "$LAST" ]; then
+            HIGHEST=$(printf '%s\n' "${LAST#v}" "$VERSION" | sort -V | tail -1)
+            if [ "$HIGHEST" != "$VERSION" ] || [ "${LAST#v}" = "$VERSION" ]; then
+              echo "Error: v$VERSION no es mayor que el último tag final ($LAST)" >&2
+              exit 1
+            fi
+          fi
+
+      - name: Crear y pushear tag
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "v$VERSION" -m "Release v$VERSION"
+          git push origin "v$VERSION"
+
+      - uses: BQN-UY/CI-CD/.github/actions/backend/scala/lint-build@v2
+        with:
+          java-version: ${{ inputs.java-version }}
+
+      - name: sbt publish
+        shell: bash
+        run: sbt publish
+
+      - name: Crear GH Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          gh release create "v$VERSION" \
+            --generate-notes \
+            --title "v$VERSION"

--- a/.github/workflows/scala-lib-publish-snapshot.yml
+++ b/.github/workflows/scala-lib-publish-snapshot.yml
@@ -1,0 +1,51 @@
+name: Scala Lib · Publish snapshot (reusable)
+
+# Reusable workflow v2 — invocar desde el repo cliente con:
+#
+#   on:
+#     push:
+#       branches: [develop]
+#   jobs:
+#     publish-snapshot:
+#       uses: BQN-UY/CI-CD/.github/workflows/scala-lib-publish-snapshot.yml@v2
+#       secrets: inherit
+#
+# Publica un snapshot a Nexus (maven-snapshots) con versión Maven-standard
+# `<base>-SNAPSHOT` derivada de sbt-dynver. NO crea tag ni GH Release —
+# el storage canónico de libs es Nexus (ver docs/v2-hito2-deploy-spec.md §1).
+#
+# Requiere en build.sbt:
+#   - dynverSeparator        := "-"
+#   - dynverSonatypeSnapshots := true
+#   - publishTo              := snapshots → Nexus maven-snapshots
+#   - crossPaths             := true   (default; conservar para libs)
+
+on:
+  workflow_call:
+    inputs:
+      java-version:
+        description: Versión de Java para sbt
+        required: false
+        type: string
+        default: "21"
+
+jobs:
+  publish-snapshot:
+    name: sbt publish → Nexus maven-snapshots
+    runs-on: ubuntu-latest
+    env:
+      TZ: America/Montevideo
+      NEXUS_USER:     ${{ secrets.NEXUS_USER }}
+      NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0          # sbt-dynver necesita historial Git completo
+
+      - uses: BQN-UY/CI-CD/.github/actions/backend/scala/lint-build@v2
+        with:
+          java-version: ${{ inputs.java-version }}
+
+      - name: sbt publish
+        shell: bash
+        run: sbt publish

--- a/templates/scala-lib/ci.yml
+++ b/templates/scala-lib/ci.yml
@@ -1,0 +1,14 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [develop, "release/**", "hotfix/**"]
+  push:
+    branches: ["release/**", "hotfix/**"]
+
+jobs:
+  ci:
+    uses: BQN-UY/CI-CD/.github/workflows/scala-lib-ci.yml@v2
+    secrets: inherit
+    # with:
+    #   java-version: "21"   # default; override solo si el proyecto usa otra versión

--- a/templates/scala-lib/make-release.yml
+++ b/templates/scala-lib/make-release.yml
@@ -1,0 +1,22 @@
+name: Make release
+
+# Disparar manualmente desde la rama `develop` (selector "Use workflow from"
+# en la UI de Actions). El tag vX.Y.Z se aplica sobre el HEAD de la rama
+# seleccionada — usar siempre develop salvo casos excepcionales.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Versión final X.Y.Z (sin prefijo v)"
+        required: true
+        type: string
+
+jobs:
+  make-release:
+    uses: BQN-UY/CI-CD/.github/workflows/scala-lib-make-release.yml@v2
+    with:
+      version: ${{ inputs.version }}
+    secrets: inherit
+    # with:
+    #   java-version: "21"   # default; override solo si el proyecto usa otra versión

--- a/templates/scala-lib/publish-snapshot.yml
+++ b/templates/scala-lib/publish-snapshot.yml
@@ -1,0 +1,12 @@
+name: Publish snapshot
+
+on:
+  push:
+    branches: [develop]
+
+jobs:
+  publish-snapshot:
+    uses: BQN-UY/CI-CD/.github/workflows/scala-lib-publish-snapshot.yml@v2
+    secrets: inherit
+    # with:
+    #   java-version: "21"   # default; override solo si el proyecto usa otra versión


### PR DESCRIPTION
## Summary

Primer set de reusable workflows v2 para librerías Scala publicadas a Nexus:

- **`scala-lib-ci.yml`** — lint + build + security (espejo de scala-api-ci).
- **`scala-lib-publish-snapshot.yml`** — push develop → `sbt publish` a Nexus `maven-snapshots` con versión Maven-standard `<base>-SNAPSHOT` (sbt-dynver).
- **`scala-lib-make-release.yml`** — workflow_dispatch con input `X.Y.Z` → tag `vX.Y.Z` + `sbt publish` a Nexus `maven-releases` + GH Release de trazabilidad.

Templates caller correspondientes en `templates/scala-lib/`.

### Decisiones de diseño

- **Separados de `scala-api-*`** aunque CI sea idéntico hoy: convención de un reusable por stack/tipo permite divergencia futura sin breaking change.
- **Sin branches `release/**` ni `hotfix/**`** para libs (Opción B): no hay deploy a ambiente que validar, los fixes salen como `X.Y.Z+1` desde develop. Si una lib específica necesita más ceremonia, se puede agregar `start-release` después sin romper retrocompatibilidad.
- **Versionado Maven-standard** (`<base>-SNAPSHOT` y `X.Y.Z`), no la convención de apps (`v<NEXT>-snapshot.NNN`). Esto fue decidido en PR #84.

### Pendiente (fuera de scope de este PR)

- `templates/scala-lib/CLAUDE.md` y `setup-labels.yml` — se incluyen cuando esté el set completo y validado.
- Update a `docs/migration-v2.md` y nuevo `docs/scala-libs-migration-v2.md`.
- Validación end-to-end en lib piloto (sugerencia: nivel 0 → `zistemas/common`).

## Test plan

- [ ] Mergear y configurar caller en lib piloto
- [ ] Validar `ci.yml` en un PR de la lib piloto
- [ ] Validar publish-snapshot mergeando un PR a develop (debe aparecer `<base>-SNAPSHOT` en Nexus)
- [ ] Validar make-release con input `0.1.0` (o el que corresponda) — debe quedar tag, GH Release y artefacto en `maven-releases`
