### PR TITLE
feat(scala): action + reusable para bump de libs internas (Fase 1 event-driven)

### DIFF
--- a/.github/actions/shared/bump-internal-lib/action.yml
+++ b/.github/actions/shared/bump-internal-lib/action.yml
@@ -1,0 +1,138 @@
+name: Bump internal lib
+description: |
+  Actualiza la versión de una librería interna en todos los `*.sbt` del repo
+  y abre un PR contra la rama target. Idempotente: si la rama ya existe upstream
+  o si no hay coincidencias, sale sin error.
+
+  Limitación conocida: solo soporta declaraciones inline del tipo
+  `"groupId" %% "artifactId" % "X.Y.Z"`. NO soporta versiones declaradas como
+  `val FuiVersion = "..."`.
+
+inputs:
+  group-id:
+    description: Maven groupId (ej. com.bqn, com.zistemas)
+    required: true
+  artifact-id:
+    description: Maven artifactId (ej. fui, db)
+    required: true
+  version:
+    description: Nueva versión (X.Y.Z, sin prefijo v)
+    required: true
+  lib-repo:
+    description: Repo GitHub de la lib (org/name) — para descripción del PR
+    required: false
+    default: ""
+  target-branch:
+    description: Rama base contra la cual abrir el PR
+    required: false
+    default: develop
+  github-token:
+    description: Token con scope `repo` para pushear rama y abrir PR (PAT, no GITHUB_TOKEN)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.target-branch }}
+        token: ${{ inputs.github-token }}
+        fetch-depth: 0
+
+    - name: Bump version en *.sbt
+      id: bump
+      shell: bash
+      env:
+        GROUP_ID:    ${{ inputs.group-id }}
+        ARTIFACT_ID: ${{ inputs.artifact-id }}
+        NEW_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        python3 - <<'PY'
+        import os, re, glob, sys
+
+        gid = os.environ['GROUP_ID']
+        aid = os.environ['ARTIFACT_ID']
+        new = os.environ['NEW_VERSION']
+
+        # Match: "groupId" %% "artifactId" % "version"
+        # Captura el prefijo completo (incluye espaciado original) y la versión vieja.
+        pattern = re.compile(
+            r'("' + re.escape(gid) + r'"\s*%%\s*"' + re.escape(aid) + r'"\s*%\s*)"([^"]+)"'
+        )
+
+        files = sorted(set(glob.glob('**/*.sbt', recursive=True)))
+        old_versions = set()
+        changed_files = []
+        already_at_new = False
+
+        for f in files:
+            with open(f) as fh:
+                src = fh.read()
+            def repl(m):
+                old_versions.add(m.group(2))
+                return f'{m.group(1)}"{new}"'
+            new_src, n = pattern.subn(repl, src)
+            if n > 0 and new_src != src:
+                with open(f, 'w') as fh:
+                    fh.write(new_src)
+                changed_files.append((f, n))
+
+        out = open(os.environ['GITHUB_OUTPUT'], 'a')
+        if not changed_files:
+            if old_versions == {new}:
+                print(f'{gid}:{aid} ya está en {new} — nada que hacer', file=sys.stderr)
+            else:
+                print(f'No se encontraron declaraciones de {gid}:{aid} en *.sbt', file=sys.stderr)
+            out.write('changed=false\n')
+            sys.exit(0)
+
+        for f, n in changed_files:
+            print(f'  {f}: {n} ocurrencia(s) actualizada(s)', file=sys.stderr)
+        out.write('changed=true\n')
+        out.write(f'old_versions={",".join(sorted(old_versions))}\n')
+        PY
+
+    - name: Crear branch + PR
+      if: steps.bump.outputs.changed == 'true'
+      shell: bash
+      env:
+        GH_TOKEN:      ${{ inputs.github-token }}
+        GROUP_ID:      ${{ inputs.group-id }}
+        ARTIFACT_ID:   ${{ inputs.artifact-id }}
+        NEW_VERSION:   ${{ inputs.version }}
+        LIB_REPO:      ${{ inputs.lib-repo }}
+        TARGET_BRANCH: ${{ inputs.target-branch }}
+        OLD_VERSIONS:  ${{ steps.bump.outputs.old_versions }}
+      run: |
+        set -euo pipefail
+        BRANCH="update/${ARTIFACT_ID}-${NEW_VERSION}"
+
+        # Idempotencia: si la rama ya existe upstream, asumimos PR ya abierto.
+        if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+          echo "Branch $BRANCH ya existe upstream — PR ya creado, salgo." >&2
+          exit 0
+        fi
+
+        git config user.name  "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git checkout -b "$BRANCH"
+        git add -A
+        git commit -m "update: bump ${GROUP_ID}:${ARTIFACT_ID} a ${NEW_VERSION}"
+        git push -u origin "$BRANCH"
+
+        REPO_LINE=""
+        if [ -n "$LIB_REPO" ]; then
+          REPO_LINE=$'\n\n'"Origen: https://github.com/${LIB_REPO}/releases/tag/v${NEW_VERSION}"
+        fi
+
+        BODY="Auto-generado por workflow \`scala-bump-internal-lib\` (CI/CD v2).
+
+        Bumpea \`${GROUP_ID}:${ARTIFACT_ID}\` de \`${OLD_VERSIONS}\` a \`${NEW_VERSION}\`.${REPO_LINE}"
+
+        gh pr create \
+          --base "$TARGET_BRANCH" \
+          --head "$BRANCH" \
+          --title "update: bump ${ARTIFACT_ID} a ${NEW_VERSION}" \
+          --body  "$BODY" \
+          --label update

--- a/.github/workflows/scala-bump-internal-lib.yml
+++ b/.github/workflows/scala-bump-internal-lib.yml
@@ -1,0 +1,71 @@
+name: Scala · Bump internal lib (reusable)
+
+# Reusable workflow v2 — receptor del evento `lib-released` emitido por
+# `scala-lib-make-release.yml` cuando se publica una release final de una lib
+# interna. Abre PR en el repo consumer bumpeando la dep en `build.sbt`.
+#
+# Invocar desde el caller del consumer:
+#
+#   on:
+#     repository_dispatch:
+#       types: [lib-released]
+#   jobs:
+#     bump:
+#       uses: BQN-UY/CI-CD/.github/workflows/scala-bump-internal-lib.yml@v2
+#       with:
+#         group-id:    ${{ github.event.client_payload.group-id }}
+#         artifact-id: ${{ github.event.client_payload.artifact-id }}
+#         version:     ${{ github.event.client_payload.version }}
+#         lib-repo:    ${{ github.event.client_payload.repo }}
+#       secrets:
+#         dispatch-token: ${{ secrets.DISPATCH_TOKEN }}
+#
+# `DISPATCH_TOKEN` es un PAT org-wide con scope `repo` — necesario porque
+# el GITHUB_TOKEN auto-provisto NO puede disparar workflows en el PR creado.
+
+on:
+  workflow_call:
+    inputs:
+      group-id:
+        description: Maven groupId de la lib publicada (ej. com.bqn)
+        required: true
+        type: string
+      artifact-id:
+        description: Maven artifactId de la lib publicada (ej. fui)
+        required: true
+        type: string
+      version:
+        description: Versión final publicada (X.Y.Z, sin prefijo v)
+        required: true
+        type: string
+      lib-repo:
+        description: Repo GitHub de la lib publicada (org/name) — para link en el PR
+        required: false
+        type: string
+        default: ""
+      target-branch:
+        description: Rama del consumer contra la que abrir el PR
+        required: false
+        type: string
+        default: develop
+    secrets:
+      dispatch-token:
+        description: PAT con scope `repo` para pushear rama y abrir PR
+        required: true
+
+jobs:
+  bump:
+    name: Bump ${{ inputs.artifact-id }} → ${{ inputs.version }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: BQN-UY/CI-CD/.github/actions/shared/bump-internal-lib@v2
+        with:
+          group-id:      ${{ inputs.group-id }}
+          artifact-id:   ${{ inputs.artifact-id }}
+          version:       ${{ inputs.version }}
+          lib-repo:      ${{ inputs.lib-repo }}
+          target-branch: ${{ inputs.target-branch }}
+          github-token:  ${{ secrets.dispatch-token }}

--- a/.github/workflows/scala-lib-ci.yml
+++ b/.github/workflows/scala-lib-ci.yml
@@ -1,0 +1,82 @@
+name: Scala Lib · CI (reusable)
+
+# Reusable workflow v2 — invocar desde el repo cliente con:
+#
+#   jobs:
+#     ci:
+#       uses: BQN-UY/CI-CD/.github/workflows/scala-lib-ci.yml@v2
+#       secrets: inherit
+
+on:
+  workflow_call:
+    inputs:
+      java-version:
+        description: Versión de Java para sbt
+        required: false
+        type: string
+        default: "21"
+
+jobs:
+  auto-label:
+    name: Auto-label PR
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: BQN-UY/CI-CD/.github/actions/shared/auto-label@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  label-check:
+    name: Verificar label de PR
+    needs: auto-label
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: BQN-UY/CI-CD/.github/actions/shared/label-check@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  pr-size-label:
+    name: Etiquetar tamaño de PR
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: BQN-UY/CI-CD/.github/actions/shared/pr-size-label@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  lint-build:
+    name: Lint & Build
+    runs-on: ubuntu-latest
+    env:
+      TZ: America/Montevideo
+      NEXUS_USER: ${{ secrets.NEXUS_USER }}
+      NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0          # sbt-dynver necesita historial Git completo
+      - uses: BQN-UY/CI-CD/.github/actions/backend/scala/lint-build@v2
+        with:
+          java-version: ${{ inputs.java-version }}
+
+  security:
+    name: Security scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write    # requerido para subir SARIF al tab de Security
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0          # detect-secrets analiza historial completo
+      - uses: BQN-UY/CI-CD/.github/actions/shared/security-scan@v2

--- a/.github/workflows/scala-lib-make-release.yml
+++ b/.github/workflows/scala-lib-make-release.yml
@@ -1,0 +1,121 @@
+name: Scala Lib · Make release (reusable)
+
+# Reusable workflow v2 — invocar desde el repo cliente con:
+#
+#   on:
+#     workflow_dispatch:
+#       inputs:
+#         version:
+#           description: "Versión final X.Y.Z (sin prefijo v)"
+#           required: true
+#           type: string
+#   jobs:
+#     make-release:
+#       uses: BQN-UY/CI-CD/.github/workflows/scala-lib-make-release.yml@v2
+#       with:
+#         version: ${{ inputs.version }}
+#       secrets: inherit
+#
+# Tag final `vX.Y.Z` sobre la rama desde la cual se dispara el workflow
+# (típicamente `develop`) → sbt publish a Nexus maven-releases con versión
+# `X.Y.Z` (sin -SNAPSHOT, derivada de sbt-dynver al detectar tag clean).
+# Crea GH Release para trazabilidad. NO usa branches release/hotfix —
+# las libs no requieren stabilización en ambiente.
+#
+# Requiere en build.sbt:
+#   - publishTo := releases → Nexus maven-releases  (cuando NO es snapshot)
+#   - dynverSeparator        := "-"
+#   - dynverSonatypeSnapshots := true
+#   - crossPaths             := true   (default; conservar para libs)
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Versión final X.Y.Z (sin prefijo v)"
+        required: true
+        type: string
+      java-version:
+        description: Versión de Java para sbt
+        required: false
+        type: string
+        default: "21"
+
+jobs:
+  make-release:
+    name: Tag + sbt publish → Nexus maven-releases
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write             # crear tag y GH Release
+    env:
+      TZ: America/Montevideo
+      NEXUS_USER:     ${{ secrets.NEXUS_USER }}
+      NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0          # sbt-dynver necesita historial Git completo
+
+      - name: Validar formato de versión
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: version debe tener formato X.Y.Z (recibido: '$VERSION')" >&2
+            exit 1
+          fi
+
+      - name: Validar que el tag no exista y sea estrictamente mayor
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          git fetch --tags --prune
+
+          if git rev-parse --verify "refs/tags/v$VERSION" >/dev/null 2>&1; then
+            echo "Error: el tag v$VERSION ya existe" >&2
+            exit 1
+          fi
+
+          LAST=$(git tag --list 'v[0-9]*' --sort=-version:refname \
+                  | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
+          if [ -n "$LAST" ]; then
+            HIGHEST=$(printf '%s\n' "${LAST#v}" "$VERSION" | sort -V | tail -1)
+            if [ "$HIGHEST" != "$VERSION" ] || [ "${LAST#v}" = "$VERSION" ]; then
+              echo "Error: v$VERSION no es mayor que el último tag final ($LAST)" >&2
+              exit 1
+            fi
+          fi
+
+      - name: Crear y pushear tag
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "v$VERSION" -m "Release v$VERSION"
+          git push origin "v$VERSION"
+
+      - uses: BQN-UY/CI-CD/.github/actions/backend/scala/lint-build@v2
+        with:
+          java-version: ${{ inputs.java-version }}
+
+      - name: sbt publish
+        shell: bash
+        run: sbt publish
+
+      - name: Crear GH Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          gh release create "v$VERSION" \
+            --generate-notes \
+            --title "v$VERSION"

--- a/.github/workflows/scala-lib-publish-snapshot.yml
+++ b/.github/workflows/scala-lib-publish-snapshot.yml
@@ -1,0 +1,51 @@
+name: Scala Lib · Publish snapshot (reusable)
+
+# Reusable workflow v2 — invocar desde el repo cliente con:
+#
+#   on:
+#     push:
+#       branches: [develop]
+#   jobs:
+#     publish-snapshot:
+#       uses: BQN-UY/CI-CD/.github/workflows/scala-lib-publish-snapshot.yml@v2
+#       secrets: inherit
+#
+# Publica un snapshot a Nexus (maven-snapshots) con versión Maven-standard
+# `<base>-SNAPSHOT` derivada de sbt-dynver. NO crea tag ni GH Release —
+# el storage canónico de libs es Nexus (ver docs/v2-hito2-deploy-spec.md §1).
+#
+# Requiere en build.sbt:
+#   - dynverSeparator        := "-"
+#   - dynverSonatypeSnapshots := true
+#   - publishTo              := snapshots → Nexus maven-snapshots
+#   - crossPaths             := true   (default; conservar para libs)
+
+on:
+  workflow_call:
+    inputs:
+      java-version:
+        description: Versión de Java para sbt
+        required: false
+        type: string
+        default: "21"
+
+jobs:
+  publish-snapshot:
+    name: sbt publish → Nexus maven-snapshots
+    runs-on: ubuntu-latest
+    env:
+      TZ: America/Montevideo
+      NEXUS_USER:     ${{ secrets.NEXUS_USER }}
+      NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0          # sbt-dynver necesita historial Git completo
+
+      - uses: BQN-UY/CI-CD/.github/actions/backend/scala/lint-build@v2
+        with:
+          java-version: ${{ inputs.java-version }}
+
+      - name: sbt publish
+        shell: bash
+        run: sbt publish

--- a/templates/scala-api/update-on-dispatch.yml
+++ b/templates/scala-api/update-on-dispatch.yml
@@ -1,0 +1,21 @@
+name: Update on dispatch
+
+# Receptor del evento `lib-released` — abre PR a develop bumpeando la dep
+# en build.sbt cuando una lib interna publica una release final.
+#
+# Requiere secret `DISPATCH_TOKEN` (PAT org-wide con scope `repo`).
+
+on:
+  repository_dispatch:
+    types: [lib-released]
+
+jobs:
+  bump:
+    uses: BQN-UY/CI-CD/.github/workflows/scala-bump-internal-lib.yml@v2
+    with:
+      group-id:    ${{ github.event.client_payload.group-id }}
+      artifact-id: ${{ github.event.client_payload.artifact-id }}
+      version:     ${{ github.event.client_payload.version }}
+      lib-repo:    ${{ github.event.client_payload.repo }}
+    secrets:
+      dispatch-token: ${{ secrets.DISPATCH_TOKEN }}

--- a/templates/scala-lib/ci.yml
+++ b/templates/scala-lib/ci.yml
@@ -1,0 +1,14 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [develop, "release/**", "hotfix/**"]
+  push:
+    branches: ["release/**", "hotfix/**"]
+
+jobs:
+  ci:
+    uses: BQN-UY/CI-CD/.github/workflows/scala-lib-ci.yml@v2
+    secrets: inherit
+    # with:
+    #   java-version: "21"   # default; override solo si el proyecto usa otra versión

--- a/templates/scala-lib/make-release.yml
+++ b/templates/scala-lib/make-release.yml
@@ -1,0 +1,22 @@
+name: Make release
+
+# Disparar manualmente desde la rama `develop` (selector "Use workflow from"
+# en la UI de Actions). El tag vX.Y.Z se aplica sobre el HEAD de la rama
+# seleccionada — usar siempre develop salvo casos excepcionales.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Versión final X.Y.Z (sin prefijo v)"
+        required: true
+        type: string
+
+jobs:
+  make-release:
+    uses: BQN-UY/CI-CD/.github/workflows/scala-lib-make-release.yml@v2
+    with:
+      version: ${{ inputs.version }}
+    secrets: inherit
+    # with:
+    #   java-version: "21"   # default; override solo si el proyecto usa otra versión

--- a/templates/scala-lib/publish-snapshot.yml
+++ b/templates/scala-lib/publish-snapshot.yml
@@ -1,0 +1,12 @@
+name: Publish snapshot
+
+on:
+  push:
+    branches: [develop]
+
+jobs:
+  publish-snapshot:
+    uses: BQN-UY/CI-CD/.github/workflows/scala-lib-publish-snapshot.yml@v2
+    secrets: inherit
+    # with:
+    #   java-version: "21"   # default; override solo si el proyecto usa otra versión

--- a/templates/scala-lib/update-on-dispatch.yml
+++ b/templates/scala-lib/update-on-dispatch.yml
@@ -1,0 +1,21 @@
+name: Update on dispatch
+
+# Receptor del evento `lib-released` — abre PR a develop bumpeando la dep
+# en build.sbt cuando una lib interna publica una release final.
+#
+# Requiere secret `DISPATCH_TOKEN` (PAT org-wide con scope `repo`).
+
+on:
+  repository_dispatch:
+    types: [lib-released]
+
+jobs:
+  bump:
+    uses: BQN-UY/CI-CD/.github/workflows/scala-bump-internal-lib.yml@v2
+    with:
+      group-id:    ${{ github.event.client_payload.group-id }}
+      artifact-id: ${{ github.event.client_payload.artifact-id }}
+      version:     ${{ github.event.client_payload.version }}
+      lib-repo:    ${{ github.event.client_payload.repo }}
+    secrets:
+      dispatch-token: ${{ secrets.DISPATCH_TOKEN }}


### PR DESCRIPTION
## Summary

**Fase 1 de C** (event-driven Scala Steward) — receptor del evento `lib-released`.

- **`shared/bump-internal-lib`** (composite): edita `build.sbt` con regex tolerante a whitespace y abre PR. Idempotente — rama existente o versión ya actual = no-op.
- **`scala-bump-internal-lib.yml`** (reusable): receptor genérico para libs y apps. Inputs tipados (`group-id`, `artifact-id`, `version`, `lib-repo`, `target-branch`).
- **`templates/{scala-lib,scala-api}/update-on-dispatch.yml`**: callers cortos sobre `repository_dispatch types: [lib-released]`.

### Diseño

- **Token**: requiere PAT org-wide `DISPATCH_TOKEN` con scope `repo` — `GITHUB_TOKEN` no puede disparar workflows en el PR creado (política GH).
- **Idempotencia**: chequea rama upstream antes de crearla; si la versión target ya está en `build.sbt`, sale como no-op.
- **Limitación conocida**: solo soporta declaraciones inline `"groupId" %% "artifactId" % "X.Y.Z"`. NO soporta vals tipo `val FuiVersion = "..."`. Documentado en el `action.yml`. Si encontramos repos que usan vals durante Fase 4 (migración), se extiende la action.
- **Una sola reusable para libs y apps**: el receptor es idéntico, no tiene sentido duplicar. Convención `<stack>-<tipo>-<workflow>` se relaja a `scala-bump-internal-lib` (sin tipo) para esta acción cross-tipo.

### Faltantes (PRs siguientes)

- **Fase 2** — Extender `scripts/build-inventory.py` (PR #90) para emitir `consumers-map.json` y `artifact-repo-map.json` parseando `build.sbt` de cada repo.
- **Fase 3** — Step final en `scala-lib-make-release.yml` que lee el map y emite `repository_dispatch` a cada consumer.
- **Fase 4** — Migrar consumers al caller `update-on-dispatch.yml`, apagar scala-steward calendario.

## Test plan

- [ ] Mergear y configurar manualmente en un repo piloto (sugerido `acp-api`):
  - Agregar caller `update-on-dispatch.yml`
  - Configurar secret `DISPATCH_TOKEN`
  - Disparar manualmente con curl: `gh api repos/BQN-UY/acp-api/dispatches -f event_type=lib-released -f 'client_payload[group-id]=com.bqn' -f 'client_payload[artifact-id]=fui' -f 'client_payload[version]=6.1.99' -f 'client_payload[repo]=BQN-UY/fui'`
  - Verificar que abre PR `update/fui-6.1.99` con bump correcto
- [ ] Probar idempotencia: disparar dos veces el mismo evento, segundo no debe abrir PR
- [ ] Probar no-op: disparar con la versión actual, no debe abrir PR
