### PR TITLE
docs: enlazar contexto organizacional de banquinet y tracking issue v2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,10 @@ Contiene composite actions reutilizables (v2), reusable workflows v2 y los reusa
 
 > **Documento canónico del modelo v2**: `docs/v2-hito2-deploy-spec.md`. Si hay conflicto entre cualquier documento y el spec, **el spec gana**. Este CLAUDE.md condensa lo operativo.
 
+## Contexto organizacional (unidad Banquinet)
+
+Equipo, roles, restricciones estructurales, herramientas, stakeholders y política IA de la unidad Banquinet: [`BQN-UY/banquinet/README.md@7ed73a7`](https://github.com/BQN-UY/banquinet/blob/7ed73a725db88473de9d32d87007b6dbc0db3ea1/README.md) (permalink al commit fijo). Útil para razonar sobre alcance, estimación y quién decide/aprueba. **Actualizar el sha del permalink cuando cambie el README canónico** del repo `BQN-UY/banquinet`.
+
 ## Estructura del repo
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,8 @@ Contiene composite actions reutilizables (v2), reusable workflows v2 y los reusa
 
 Equipo, roles, restricciones estructurales, herramientas, stakeholders y política IA de la unidad Banquinet: [`BQN-UY/banquinet/README.md@7ed73a7`](https://github.com/BQN-UY/banquinet/blob/7ed73a725db88473de9d32d87007b6dbc0db3ea1/README.md) (permalink al commit fijo). Útil para razonar sobre alcance, estimación y quién decide/aprueba. **Actualizar el sha del permalink cuando cambie el README canónico** del repo `BQN-UY/banquinet`.
 
+**Tracking cross-repo de esta iniciativa**: issue canónico [`BQN-UY/banquinet#3 — Tracking — CI/CD v2`](https://github.com/BQN-UY/banquinet/issues/3). Fuente única de verdad del estado global de la migración v2. Este repo mantiene spec + código; el estado organizacional de la iniciativa vive allí. Convención de uso: [`BQN-UY/banquinet/docs/TRACKING.md`](https://github.com/BQN-UY/banquinet/blob/main/docs/TRACKING.md).
+
 ## Estructura del repo
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Contiene composite actions reutilizables (v2), reusable workflows v2 y los reusa
 
 ## Contexto organizacional (unidad Banquinet)
 
-Equipo, roles, restricciones estructurales, herramientas, stakeholders y política IA de la unidad Banquinet: [`BQN-UY/banquinet/README.md@7ed73a7`](https://github.com/BQN-UY/banquinet/blob/7ed73a725db88473de9d32d87007b6dbc0db3ea1/README.md) (permalink al commit fijo). Útil para razonar sobre alcance, estimación y quién decide/aprueba. **Actualizar el sha del permalink cuando cambie el README canónico** del repo `BQN-UY/banquinet`.
+Equipo, roles, restricciones estructurales, herramientas, stakeholders y política IA de la unidad Banquinet: [`BQN-UY/banquinet/README.md@8fb0749`](https://github.com/BQN-UY/banquinet/blob/8fb07499762e059a3ca49cf960f9bd1f66cda5e4/README.md) (permalink al commit fijo). Útil para razonar sobre alcance, estimación y quién decide/aprueba. **Actualizar el sha del permalink cuando cambie el README canónico** del repo `BQN-UY/banquinet`.
 
 **Tracking cross-repo de esta iniciativa**: issue canónico [`BQN-UY/banquinet#3 — Tracking — CI/CD v2`](https://github.com/BQN-UY/banquinet/issues/3). Fuente única de verdad del estado global de la migración v2. Este repo mantiene spec + código; el estado organizacional de la iniciativa vive allí. Convención de uso: [`BQN-UY/banquinet/docs/TRACKING.md`](https://github.com/BQN-UY/banquinet/blob/main/docs/TRACKING.md).
 

--- a/templates/scala-api/CLAUDE.md
+++ b/templates/scala-api/CLAUDE.md
@@ -10,6 +10,10 @@ en `BQN-UY/CI-CD` y se propaga automáticamente a todos los proyectos que pinean
 `@v2`. Los archivos `.github/workflows/*.yml` de este repo solo cambian cuando
 hay que ajustar inputs o triggers específicos del proyecto.
 
+## Contexto organizacional (unidad Banquinet)
+
+Equipo, roles, restricciones estructurales, herramientas, stakeholders y política IA de la unidad Banquinet: [`BQN-UY/banquinet/README.md@7ed73a7`](https://github.com/BQN-UY/banquinet/blob/7ed73a725db88473de9d32d87007b6dbc0db3ea1/README.md) (permalink al commit fijo). Útil para razonar sobre alcance, estimación y quién decide/aprueba. **Actualizar el sha del permalink cuando cambie el README canónico** del repo `BQN-UY/banquinet`.
+
 ## Branching model
 
 ### Ramas de trabajo (corta duración — siempre via PR)

--- a/templates/scala-api/CLAUDE.md
+++ b/templates/scala-api/CLAUDE.md
@@ -12,7 +12,7 @@ hay que ajustar inputs o triggers específicos del proyecto.
 
 ## Contexto organizacional (unidad Banquinet)
 
-Equipo, roles, restricciones estructurales, herramientas, stakeholders y política IA de la unidad Banquinet: [`BQN-UY/banquinet/README.md@7ed73a7`](https://github.com/BQN-UY/banquinet/blob/7ed73a725db88473de9d32d87007b6dbc0db3ea1/README.md) (permalink al commit fijo). Útil para razonar sobre alcance, estimación y quién decide/aprueba. **Actualizar el sha del permalink cuando cambie el README canónico** del repo `BQN-UY/banquinet`.
+Equipo, roles, restricciones estructurales, herramientas, stakeholders y política IA de la unidad Banquinet: [`BQN-UY/banquinet/README.md@8fb0749`](https://github.com/BQN-UY/banquinet/blob/8fb07499762e059a3ca49cf960f9bd1f66cda5e4/README.md) (permalink al commit fijo). Útil para razonar sobre alcance, estimación y quién decide/aprueba. **Actualizar el sha del permalink cuando cambie el README canónico** del repo `BQN-UY/banquinet`.
 
 ## Branching model
 


### PR DESCRIPTION
## Summary

- **Contexto organizacional** — agrega sección *Contexto organizacional (unidad Banquinet)* en `CLAUDE.md` raíz y en `templates/scala-api/CLAUDE.md`, con permalink fijo al `README.md` del repo canónico [`BQN-UY/banquinet`](https://github.com/BQN-UY/banquinet). Al estar en el template, futuras migraciones a v2 heredan el link sin trabajo extra.
- **Tracking issue canónico** — agrega pointer al issue [`BQN-UY/banquinet#3 — Tracking — CI/CD v2`](https://github.com/BQN-UY/banquinet/issues/3), fuente única de verdad del estado global de la migración, siguiendo la convención [`banquinet/docs/TRACKING.md`](https://github.com/BQN-UY/banquinet/blob/main/docs/TRACKING.md).
- **Bump de SHA** — actualiza el permalink del README de `7ed73a7` → `8fb0749` (HEAD post merge de PR #2 de banquinet, que introdujo la convención TRACKING y el bullet correspondiente en el README).

## Motivación

`BQN-UY/banquinet` concentra el contexto organizacional de la unidad (equipo, roles, restricciones, herramientas, stakeholders, política IA, **convención de tracking cross-repo**) como fuente canónica portátil. Linkearlo desde cada `CLAUDE.md` + apuntar al tracking issue permite que agentes AI y humanos tengan ese contexto y el estado global sin duplicarlos por repo.

## Estándar cross-repo

Todo repo de la unidad debería incluir esta sección en su `CLAUDE.md` / `AGENTS.md` al migrar a v2. La sub-sección del tracking issue aplica específicamente a repos driver de una iniciativa cross-repo (acá, CI-CD); el resto de los repos participantes solo necesitan el link al README canónico.

## Test plan

- [ ] Los permalinks del diff abren el README/issue/convención correctos.
- [ ] La nota "Actualizar el sha del permalink cuando cambie el README canónico" sigue vigente en ambos CLAUDE.md.
- [ ] El issue `BQN-UY/banquinet#3` tiene labels `status:active` + `scope:cross-repo` y está vinculado al project Banquinet #13.
- [ ] Tras merge, al clonar el template scala-api en un proyecto nuevo, el link al contexto organizacional viene de arranque.