### PR TITLE
chore: bump composite checkout a v6 + ignore pycache

### DIFF
--- a/.github/actions/shared/bump-internal-lib/action.yml
+++ b/.github/actions/shared/bump-internal-lib/action.yml
@@ -33,7 +33,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: ${{ inputs.target-branch }}
         token: ${{ inputs.github-token }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.idea/
+scripts/__pycache__/


### PR DESCRIPTION
## Summary

Housekeeping que quedó fuera del PR [#88](https://github.com/BQN-UY/CI-CD/pull/88) de Dependabot:

- `.github/actions/shared/bump-internal-lib/action.yml` — `actions/checkout` de v4 a v6. Dependabot no escanea composite actions (`.github/actions/*`), solo workflows (`.github/workflows/*`), por eso esta bajada quedó pendiente tras #88. Con este cambio, todos los \`actions/checkout\` del repo quedan alineados en v6.
- `.gitignore` — agregar `scripts/__pycache__/` para que no vuelva a aparecer en `git status` cuando se corre alguno de los scripts Python del repo.

## Test plan

- [ ] El composite sigue cumpliendo su contrato: checkout del repo target-branch con el token provisto. No hay breaking changes entre v4 y v6 relevantes para este uso (persist-credentials sigue ok).
- [ ] Tras merge, `git status` en un working tree que acaba de correr `scripts/*.py` muestra tree limpio.