### PR TITLE
docs: actualizar stubs tras banquinet PR #8 (rename + transfer)

### DIFF
--- a/docs/policy-ai-coding.md
+++ b/docs/policy-ai-coding.md
@@ -6,6 +6,6 @@
 >
 > **Razón.** La política aplica a todo dev BQN-UY y a commits de cualquier repo de la organización — no es específica de CI/CD. Se movió a `banquinet` (repo de contexto organizacional) donde corresponde su alcance.
 >
-> **Origen.** Doc creado en este repo en commit [`d8d9846`](https://github.com/BQN-UY/CI-CD/commit/d8d9846) (2026-04-15). Movido a banquinet en PR [`BQN-UY/banquinet#4`](https://github.com/BQN-UY/banquinet/pull/4) (2026-04-18). Review del contenido continúa en issue [`#97`](https://github.com/BQN-UY/CI-CD/issues/97) (pendiente de transfer a banquinet).
+> **Origen.** Doc creado en este repo en commit [`d8d9846`](https://github.com/BQN-UY/CI-CD/commit/d8d9846) (2026-04-15). Movido a banquinet en PR [`BQN-UY/banquinet#4`](https://github.com/BQN-UY/banquinet/pull/4) (2026-04-18). Review del contenido continúa en [`BQN-UY/banquinet#6`](https://github.com/BQN-UY/banquinet/issues/6) (issue transferido desde `BQN-UY/CI-CD#97`).
 >
 > **Este stub.** Se conserva para estabilidad de live links que apuntan a esta ruta. Puede eliminarse tras 1-2 ciclos de operación sin roturas.

--- a/docs/v2-github-automation-identity.md
+++ b/docs/v2-github-automation-identity.md
@@ -2,10 +2,10 @@
 
 > **Movido a `BQN-UY/banquinet`.**
 >
-> Este documento ahora vive en [`BQN-UY/banquinet/docs/v2-github-automation-identity.md`](https://github.com/BQN-UY/banquinet/blob/main/docs/v2-github-automation-identity.md).
+> Este documento ahora vive en [`BQN-UY/banquinet/docs/github-automation-identity.md`](https://github.com/BQN-UY/banquinet/blob/main/docs/github-automation-identity.md).
 >
-> **Razón.** La decisión GitHub App vs PAT vs machine user aplica a cualquier automatización de la organización (Scala Steward, Dependabot, back-merges, bots futuros) — no solo al deploy v2. Se movió a `banquinet` donde corresponde su alcance organizacional. El trigger histórico fue CI/CD v2 libs (Fase 4), de ahí el prefijo `v2-` que puede limpiarse en una cleanup posterior.
+> **Razón.** La decisión GitHub App vs PAT vs machine user aplica a cualquier automatización de la organización (Scala Steward, Dependabot, back-merges, bots futuros) — no solo al deploy v2. Se movió a `banquinet` donde corresponde su alcance organizacional.
 >
-> **Origen.** Doc creado en este repo en commit [`79bfdd3`](https://github.com/BQN-UY/CI-CD/commit/79bfdd3) (2026-04-16). Movido a banquinet en PR [`BQN-UY/banquinet#4`](https://github.com/BQN-UY/banquinet/pull/4) (2026-04-18). Review del contenido continúa en issue [`#96`](https://github.com/BQN-UY/CI-CD/issues/96) (pendiente de transfer a banquinet).
+> **Origen.** Doc creado en este repo en commit [`79bfdd3`](https://github.com/BQN-UY/CI-CD/commit/79bfdd3) (2026-04-16). Movido a banquinet en PR [`BQN-UY/banquinet#4`](https://github.com/BQN-UY/banquinet/pull/4) (2026-04-18) y renombrado a `github-automation-identity.md` en [`BQN-UY/banquinet#8`](https://github.com/BQN-UY/banquinet/pull/8). Review del contenido continúa en [`BQN-UY/banquinet#5`](https://github.com/BQN-UY/banquinet/issues/5) (issue transferido desde `BQN-UY/CI-CD#96`).
 >
 > **Este stub.** Se conserva para estabilidad de live links que apuntan a esta ruta. Puede eliminarse tras 1-2 ciclos de operación sin roturas.


### PR DESCRIPTION
## Summary

[`BQN-UY/banquinet#8`](https://github.com/BQN-UY/banquinet/pull/8) (mergeado) renombró los docs organizacionales en banquinet y limpió referencias. Los stubs en este repo quedaron con info desactualizada. Se actualizan para no depender del redirect 301 de GitHub:

- `docs/v2-github-automation-identity.md` (stub) — link al nuevo path [`banquinet/.../github-automation-identity.md`](https://github.com/BQN-UY/banquinet/blob/main/docs/github-automation-identity.md); removido el "prefijo v2- a limpiar" (ya se hizo); referencia al review actualizada a [`banquinet#5`](https://github.com/BQN-UY/banquinet/issues/5).
- `docs/policy-ai-coding.md` (stub) — referencia al review actualizada a [`banquinet#6`](https://github.com/BQN-UY/banquinet/issues/6) (transfer ya ejecutado). El link al doc mismo no cambió (policy-ai-coding.md mantuvo nombre).

## Fuera de alcance

- Renombrar los stubs para que matcheen los nuevos nombres (ej. `v2-github-automation-identity.md` → `github-automation-identity.md`): **NO** hay que hacerlo. La ruta vieja es exactamente lo que el stub debe preservar para estabilidad de live links. Renombrar el stub anularía su función.
- Cleanup de stubs (removal total): sigue pendiente para PR separado tras 1-2 ciclos sin roturas, como previsto.

## Test plan

- [ ] El link en cada stub abre el doc correcto en banquinet.
- [ ] Las referencias a issues de review apuntan a los issues transferidos (#5 y #6 en banquinet), no a los originales cerrados en CI-CD.