### PR TITLE
docs(spec): explicitar dependencia libs v2 → banquinet#5

### DIFF
--- a/docs/v2-hito2-deploy-spec.md
+++ b/docs/v2-hito2-deploy-spec.md
@@ -22,7 +22,7 @@ Documento canónico del diseño del deploy GA-native que reemplaza a Jenkins en 
 
 Este Hito 2 cubre **server apps**. Client apps y libs se documentan en sus propios specs/templates cuando corresponda.
 
-> **Libs v2 — infra implementada, activación con dependencia cruzada**: los reusable workflows de libs Scala (PRs [#91](https://github.com/BQN-UY/CI-CD/pull/91)–[#94](https://github.com/BQN-UY/CI-CD/pull/94), todos mergeados) están operativos. La Fase 4 de activación depende de la decisión de identidad de automatizaciones en [`BQN-UY/banquinet#5`](https://github.com/BQN-UY/banquinet/issues/5) — no solo de los secrets técnicos de la Fase 0 de server apps. La naturaleza de las credenciales que consume `inventory.yml` y el paso de propagación `repository_dispatch` de `scala-lib-make-release.yml` (GitHub App vs PAT clásico) se decide allí. Tracking de la activación: [`BQN-UY/CI-CD#99`](https://github.com/BQN-UY/CI-CD/issues/99). Estado global: [`BQN-UY/banquinet#3`](https://github.com/BQN-UY/banquinet/issues/3).
+> **Libs v2 — infra implementada, activación con dependencia cruzada**: los reusable workflows de libs Scala (PRs [#91](https://github.com/BQN-UY/CI-CD/pull/91)–[#94](https://github.com/BQN-UY/CI-CD/pull/94), todos mergeados) están operativos. La activación end-to-end depende de la decisión de identidad de automatizaciones en [`BQN-UY/banquinet#5`](https://github.com/BQN-UY/banquinet/issues/5) — no solo de los secrets técnicos ya identificados para server apps. La naturaleza de las credenciales que consume `inventory.yml` y el paso de propagación `repository_dispatch` de `scala-lib-make-release.yml` (GitHub App vs PAT clásico) se decide allí. Tracking de la activación: [`BQN-UY/CI-CD#99`](https://github.com/BQN-UY/CI-CD/issues/99). Estado global: [`BQN-UY/banquinet#3`](https://github.com/BQN-UY/banquinet/issues/3).
 
 ```mermaid
 flowchart LR
@@ -434,4 +434,4 @@ Documentos por jerarquía de autoridad:
 
 **Cuando el usuario pregunta "¿v2 usa Jenkins?"**: NO. Ver Principio rector + `docs/v2-sin-jenkins-roadmap.md`.
 
-**Cuando el usuario pregunta sobre libs**: este spec NO las cubre — siguen el modelo Maven-standard en Nexus. Infra implementada (`templates/scala-lib/`, reusable workflows `scala-lib-*.yml`, propagación event-driven); activación (Fase 4) bloqueada por [`BQN-UY/banquinet#5`](https://github.com/BQN-UY/banquinet/issues/5) — ver nota en §1 y tracking en [`BQN-UY/CI-CD#99`](https://github.com/BQN-UY/CI-CD/issues/99).
+**Cuando el usuario pregunta sobre libs**: este spec NO las cubre — siguen el modelo Maven-standard en Nexus. Infra implementada (`templates/scala-lib/`, reusable workflows `scala-lib-*.yml`, propagación event-driven); activación end-to-end bloqueada por [`BQN-UY/banquinet#5`](https://github.com/BQN-UY/banquinet/issues/5) — ver nota en §1 y tracking en [`BQN-UY/CI-CD#99`](https://github.com/BQN-UY/CI-CD/issues/99).

--- a/docs/v2-hito2-deploy-spec.md
+++ b/docs/v2-hito2-deploy-spec.md
@@ -22,6 +22,8 @@ Documento canónico del diseño del deploy GA-native que reemplaza a Jenkins en 
 
 Este Hito 2 cubre **server apps**. Client apps y libs se documentan en sus propios specs/templates cuando corresponda.
 
+> **Libs v2 — infra implementada, activación con dependencia cruzada**: los reusable workflows de libs Scala (PRs [#91](https://github.com/BQN-UY/CI-CD/pull/91)–[#94](https://github.com/BQN-UY/CI-CD/pull/94), todos mergeados) están operativos. La Fase 4 de activación depende de la decisión de identidad de automatizaciones en [`BQN-UY/banquinet#5`](https://github.com/BQN-UY/banquinet/issues/5) — no solo de los secrets técnicos de la Fase 0 de server apps. La naturaleza de las credenciales que consume `inventory.yml` y el paso de propagación `repository_dispatch` de `scala-lib-make-release.yml` (GitHub App vs PAT clásico) se decide allí. Tracking de la activación: [`BQN-UY/CI-CD#99`](https://github.com/BQN-UY/CI-CD/issues/99). Estado global: [`BQN-UY/banquinet#3`](https://github.com/BQN-UY/banquinet/issues/3).
+
 ```mermaid
 flowchart LR
     subgraph srv["Server apps (APIs, WARs, python servers)"]
@@ -432,4 +434,4 @@ Documentos por jerarquía de autoridad:
 
 **Cuando el usuario pregunta "¿v2 usa Jenkins?"**: NO. Ver Principio rector + `docs/v2-sin-jenkins-roadmap.md`.
 
-**Cuando el usuario pregunta sobre libs**: este spec NO las cubre — siguen el modelo Maven-standard en Nexus. Cuando exista, ver `templates/scala-lib/`.
+**Cuando el usuario pregunta sobre libs**: este spec NO las cubre — siguen el modelo Maven-standard en Nexus. Infra implementada (`templates/scala-lib/`, reusable workflows `scala-lib-*.yml`, propagación event-driven); activación (Fase 4) bloqueada por [`BQN-UY/banquinet#5`](https://github.com/BQN-UY/banquinet/issues/5) — ver nota en §1 y tracking en [`BQN-UY/CI-CD#99`](https://github.com/BQN-UY/CI-CD/issues/99).


### PR DESCRIPTION
## Summary

- Hace explícita en el spec canónico (`docs/v2-hito2-deploy-spec.md`) la dependencia cruzada **libs v2 → automation identity** (`BQN-UY/banquinet#5`), que hasta ahora vivía solo en el tracking issue y en `BQN-UY/CI-CD#99`.
- Actualiza §1 con una nota tras el alcance del spec: infra libs implementada (PRs #91-#94), pero Fase 4 de activación bloqueada por `banquinet#5` — no solo por Fase 0 técnica.
- Actualiza §10 (navegación AI) para reflejar que `templates/scala-lib/` ya existe y apuntar al blocker activo.

Ítem #1 de la lista de housekeeping capturada en `banquinet#3` (comment del 2026-04-18).

## Test plan

- [ ] Revisar que los links a `banquinet#5`, `banquinet#3` y `CI-CD#99` resuelvan correctamente
- [ ] Revisar que no haya conflicto con otras secciones del spec (escaneo visual)