### PR TITLE
docs: política del tag `v2` de este repo

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,6 +38,10 @@ Repositorio centralizado de CI/CD. Composite actions v2 viven en `.github/action
 - `v*-rc.*` → protegido (RCs auditados inmutables)
 - `v*-snapshot.*` → libre (cleanup borra)
 
+## Tag `v2` de este repo (CI-CD)
+
+Móvil por diseño — consumers referencian `BQN-UY/CI-CD@v2`. **No protegido** (requiere force-push). Mover al HEAD de main cuando el PR toca `.github/actions/**`, `.github/workflows/<stack>-*.yml` o `templates/**`. No mover para cambios doc-only (`docs/**`, `CLAUDE.md`, `copilot-instructions.md`). Comando: `git tag -f v2 origin/main && git push -f origin v2`.
+
 ## Estructura de una action v2
 
 ```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,7 +40,7 @@ Repositorio centralizado de CI/CD. Composite actions v2 viven en `.github/action
 
 ## Tag `v2` de este repo (CI-CD)
 
-Móvil por diseño — consumers referencian `BQN-UY/CI-CD@v2`. **No protegido** (requiere force-push). Mover al HEAD de main cuando el PR toca `.github/actions/**`, `.github/workflows/<stack>-*.yml` o `templates/**`. No mover para cambios doc-only (`docs/**`, `CLAUDE.md`, `copilot-instructions.md`). Comando: `git tag -f v2 origin/main && git push -f origin v2`.
+Móvil por diseño — consumers referencian `BQN-UY/CI-CD@v2`. **No protegido** (requiere force-push). Mover al HEAD de main cuando el PR toca `.github/actions/**`, `.github/workflows/<stack>-<tipo>-*.yml` (reusables v2) o `templates/**`. No mover para cambios doc-only (`docs/**`, `CLAUDE.md`, `.github/copilot-instructions.md`) ni para workflows v1 legacy. Comando: `git tag -f v2 origin/main && git push -f origin v2`.
 
 ## Estructura de una action v2
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,32 @@ Detalle completo en `docs/v2-hito2-deploy-spec.md` §1.
 | `v*-rc.*` | delete + force-push | RCs auditados son inmutables |
 | `v*-snapshot.*` | (libre) | cleanup workflow necesita borrarlos |
 
+## Tag `v2` de este repo
+
+Los consumers (repos de proyecto) referencian este repo vía `BQN-UY/CI-CD@v2` en sus callers. A diferencia de los tags de repos app (inmutables), **`v2` de este repo es móvil por diseño** — se mueve al HEAD de main bajo criterio explícito. **No debe estar protegido** en Settings → Tag protection (requiere force-push).
+
+**Regla — cuándo mover** (según los paths tocados por el PR mergeado):
+
+| Paths tocados | ¿Mueve `v2`? |
+|---|---|
+| `.github/actions/**` | Sí |
+| `.github/workflows/<stack>-*.yml` (v2) | Sí |
+| `templates/**` | Sí |
+| `docs/**`, `CLAUDE.md`, `.github/copilot-instructions.md` | No |
+| Workflows v1 legacy | No |
+
+**Cómo mover** (post-merge, autor del PR o Pablo):
+
+```bash
+git fetch origin main
+git tag -f v2 origin/main
+git push -f origin v2
+```
+
+**Checkpoint por hito**: al cerrar cada hito (1, 2, 3, 4, 5), auditar con `git log v2..main --oneline` que no queden commits code-visible sin propagar.
+
+**Escape para consumers**: quien necesite congelación total puede pinear al SHA (ej. `BQN-UY/CI-CD@<sha>`) en vez de `@v2`. Cuando exista versionado semver del propio CI-CD (`vX.Y.Z`), también será opción.
+
 ## Ambientes (deploy v2 server apps)
 
 | Rama del proyecto | Ambiente | Propósito |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,12 +87,12 @@ Los consumers (repos de proyecto) referencian este repo vía `BQN-UY/CI-CD@v2` e
 | Paths tocados | ¿Mueve `v2`? |
 |---|---|
 | `.github/actions/**` | Sí |
-| `.github/workflows/<stack>-*.yml` (v2) | Sí |
+| `.github/workflows/<stack>-<tipo>-*.yml` (reusables v2, ej. `scala-api-ci.yml`, `scala-lib-publish-snapshot.yml`) | Sí |
 | `templates/**` | Sí |
 | `docs/**`, `CLAUDE.md`, `.github/copilot-instructions.md` | No |
-| Workflows v1 legacy | No |
+| Resto de `.github/workflows/*.yml` (v1 legacy, lista explícita en §Reglas) | No |
 
-**Cómo mover** (post-merge, autor del PR o Pablo):
+**Cómo mover** (post-merge, a cargo del maintainer del repo):
 
 ```bash
 git fetch origin main


### PR DESCRIPTION
## Summary

Documenta cuándo mover el tag `v2` de este repo. Hoy quedó en `3c31863` (Hito 2 §7) con 11 commits de main por delante — de ellos, 2 son code-visible (bumps de composite checkout) y 9 son doc-only.

- **Regla**: `v2` se mueve al HEAD de main cuando el PR toca `.github/actions/**`, `.github/workflows/<stack>-*.yml` (v2) o `templates/**`. No se mueve para cambios doc-only (`docs/**`, `CLAUDE.md`, `copilot-instructions.md`) ni para workflows v1 legacy.
- **Tag no protegido**: requiere force-push.
- **Checkpoint por hito**: auditar `git log v2..main --oneline` al cerrar cada hito.
- **Escape**: consumers que necesiten congelación total pinean al SHA o (a futuro) a tag semver del propio CI-CD.

Tras mergear este PR: bump manual de `v2` → HEAD (este PR es doc-only pero arrastra #88 y #102 pendientes; alinear estado al documentar simplifica). Futuro fuera de scope: workflow que automatice el bump post-merge.

Ítem #2 del housekeeping capturado en `banquinet#3`.

## Test plan

- [ ] Revisar que la regla cubra los paths correctos (ej. casos borde: ¿y si un PR toca `docs/` + `.github/actions/`? → sí mueve)
- [ ] Revisar que CLAUDE.md y copilot-instructions.md queden consistentes