### PR TITLE
docs: formalizar ritual de update al tracking issue banquinet#3

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,6 +2,8 @@
 
 > **Doc canónico**: `docs/v2-hito2-deploy-spec.md`. Si hay conflicto, ese gana.
 
+> **Tracking cross-repo**: `BQN-UY/banquinet#3` es fuente única del estado global de la migración v2. Al cerrar PR/issue que avanza hito, cierra blocker, o formaliza política v2: postear update comment al issue (formato `## Update YYYY-MM-DD — <agente/sesión>` con Hito/Próximo/Bloqueos/Links). Convención en `banquinet/docs/TRACKING.md`. NO aplica para typos, renames internos, ni dependabot bumps sin cambio de API.
+
 ## Qué es este repo
 
 Repositorio centralizado de CI/CD. Composite actions v2 viven en `.github/actions/`. Reusable workflows v2 (con prefijo `<stack>-`) viven en `.github/workflows/`. Workflows sin prefijo en `.github/workflows/` son **v1 legacy** — no modificar.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Equipo, roles, restricciones estructurales, herramientas, stakeholders y políti
 
 ### Ritual — update al tracking issue
 
-Al cerrar un PR o issue que cambia material el estado de la migración v2, postear un **update comment** a [`banquinet#3`](https://github.com/BQN-UY/banquinet/issues/3). Previene fragmentación de contexto entre sesiones.
+Al cerrar un PR o issue que cambia materialmente el estado de la migración v2, postear un **update comment** a [`banquinet#3`](https://github.com/BQN-UY/banquinet/issues/3). Previene fragmentación de contexto entre sesiones.
 
 **Aplica cuando** el cambio:
 - cierra o avanza un hito del roadmap v2 (1, 2, 2bis, 3, 4, 5),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,31 @@ Equipo, roles, restricciones estructurales, herramientas, stakeholders y políti
 
 **Tracking cross-repo de esta iniciativa**: issue canónico [`BQN-UY/banquinet#3 — Tracking — CI/CD v2`](https://github.com/BQN-UY/banquinet/issues/3). Fuente única de verdad del estado global de la migración v2. Este repo mantiene spec + código; el estado organizacional de la iniciativa vive allí. Convención de uso: [`BQN-UY/banquinet/docs/TRACKING.md`](https://github.com/BQN-UY/banquinet/blob/main/docs/TRACKING.md).
 
+### Ritual — update al tracking issue
+
+Al cerrar un PR o issue que cambia material el estado de la migración v2, postear un **update comment** a [`banquinet#3`](https://github.com/BQN-UY/banquinet/issues/3). Previene fragmentación de contexto entre sesiones.
+
+**Aplica cuando** el cambio:
+- cierra o avanza un hito del roadmap v2 (1, 2, 2bis, 3, 4, 5),
+- cierra o identifica un bloqueo externo,
+- modifica composites, reusable workflows, templates o specs canónicos (`docs/v2-*-spec.md`, `docs/v2-*-roadmap.md`),
+- formaliza políticas (tag `v2`, IA, versionado, secrets, automation identity, ritual de tracking).
+
+**NO aplica** para cambios operativos sin impacto en estado organizacional (typos, renames internos, dependabot bumps sin cambio de API expuesta a consumers).
+
+**Formato del comment** (convención de [`TRACKING.md`](https://github.com/BQN-UY/banquinet/blob/main/docs/TRACKING.md) §2.1):
+
+```markdown
+## Update YYYY-MM-DD — <agente/sesión>
+
+- **Hito**: qué se cerró/avanzó + links a PRs/commits.
+- **Próximo**: próximos candidatos (resaltar los autónomos sin bloqueos externos).
+- **Bloqueos**: cambios en bloqueos externos.
+- **Links**: PRs, commits, issues relevantes.
+```
+
+Si además corresponde actualizar el **body** del issue (snapshot vivo — ej. marcar hito como hecho, agregar housekeeping nuevo, cambiar bloqueos activos), editar el body primero y dejar un comment corto adicional (`## Update YYYY-MM-DD — body actualizado`) explicando la edición. Nunca sobreescribir comentarios ajenos; si hay conflicto al editar el body, re-leer y re-aplicar, explicitándolo en el comentario.
+
 ## Estructura del repo
 
 ```


### PR DESCRIPTION
## Summary

Documenta el ritual de postear update comments al tracking issue [\`BQN-UY/banquinet#3\`](https://github.com/BQN-UY/banquinet/issues/3) al cerrar PRs/issues relevantes a v2 — hasta ahora era convención implícita, sesiones podían olvidarlo y fragmentar contexto entre conversaciones.

- **CLAUDE.md**: subsección nueva "Ritual — update al tracking issue" dentro de "Contexto organizacional". Cubre cuándo aplica, cuándo no, formato del comment (alineado con \`banquinet/docs/TRACKING.md\` §2.1), y cómo editar el body del issue cuando corresponda.
- **copilot-instructions.md**: callout corto en el header.

Ítem #5 del housekeeping capturado en \`banquinet#3\`.

## Test plan

- [ ] La lista de "aplica cuando" cubre los casos reales (hitos, blockers, composites/reusables/specs, políticas).
- [ ] La lista de "NO aplica" no deja ambigüedad con casos borde (dependabot que bump-ea composite checkout v5→v6 sí afecta API? — hoy se consideró code-visible, coherente con regla de tag v2).