### PR TITLE
fix(scala-make-release-lib): comparar contra último tag, ignorar version.sbt

### DIFF
--- a/.github/workflows/scala-make-release-lib.yml
+++ b/.github/workflows/scala-make-release-lib.yml
@@ -28,17 +28,33 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
-      - name: Get scala changed files
+      - name: Get last release tag SHA
+        id: last-tag
+        run: |
+          last_tag=$(git describe --tags --abbrev=0 --match='v*' 2>/dev/null || true)
+          if [ -z "$last_tag" ]; then
+            echo "No release tag found; using root commit as base."
+            echo "sha=$(git rev-list --max-parents=0 HEAD | head -1)" >> "$GITHUB_OUTPUT"
+          else
+            echo "Comparing against last release tag: $last_tag"
+            echo "sha=$(git rev-list -n 1 "$last_tag")" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Get scala changed files since last release
         id: changed-scala-files
         uses: tj-actions/changed-files@v47
         with:
+          base_sha: ${{ steps.last-tag.outputs.sha }}
           dir_names: "true"
           files: |
             *.sbt
             **/*.sbt
-            **/*.scala     
+            **/*.scala
+          files_ignore: |
+            version.sbt
+            **/version.sbt
 
   make-release:
     needs: check-changes


### PR DESCRIPTION
## Problema

El reusable `scala-make-release-lib.yml` tiene un gate `check-changes` para evitar publicar libs sin cambios reales. **El gate está roto**: detecta como "cambio" el bump de `version.sbt` que el propio `sbt release` deja en main después de cada release, disparando un nuevo release en el siguiente cron — y así sucesivamente.

### Caso documentado: `bol-protocol`

Publicó **9 releases consecutivos** con body "No changes" en cadencia de ~11 días (alineada al `cron: "15 9 */11 * *"` de su `make-release.yml`):

| Release | Fecha | Body |
|---|---|---|
| v3.24.0 | 2026-02-03 | (con contenido real — última sana) |
| v3.25.0 | 2026-02-12 | No changes |
| v3.26.0 | 2026-02-23 | No changes |
| v3.27.0 | 2026-03-01 | No changes |
| v3.28.0 | 2026-03-12 | No changes |
| v3.29.0 | 2026-03-23 | No changes |
| v3.30.0 | 2026-04-01 | No changes |
| v3.31.0 | 2026-04-12 | No changes |
| v3.32.0 | 2026-04-23 | No changes |
| v3.33.0 | 2026-05-01 | No changes |

### Mecánica del bug

`check-changes` corre `actions/checkout@v6` con `fetch-depth: 2` y luego `tj-actions/changed-files@v47` matcheando `*.sbt`/`**/*.sbt`/`**/*.scala`. Sin `base_sha` configurado, `tj-actions/changed-files` compara HEAD contra HEAD~1.

Después de un release ejecutado por sbt-release:

1. Commit Y: `Setting version to 3.33.0` (release commit, taggeado v3.33.0)
2. Commit Z: `Setting version to 3.34.0-SNAPSHOT` (post-release bump)

`HEAD = Z`, `HEAD~1 = Y`. Diff verificado en bol-protocol (`gh api repos/BQN-UY/bol-protocol/compare/4b042b3...815d4ec`):

```
files:
  - version.sbt: modified (+1/-1)
```

Solo `version.sbt`. Pero matchea `*.sbt` → `any_changed=true` → gate pasa → release fantasma → bump → loop.

Adicionalmente, `fetch-depth: 2` solo ve el último commit, perdiendo cambios de desarrollo en commits anteriores aún no liberados (por ejemplo: si entre cron y cron entran un cambio en .scala y luego un cambio en README.md, el cron solo ve README.md y no detecta el .scala pendiente).

## Fix

Dos cambios combinados:

1. **`fetch-depth: 0`** — historial completo, necesario para resolver tags.
2. **`base_sha = SHA del último tag `v*`** — el diff se computa "desde el último release real", no contra el último commit. Resuelve los dos bugs (fantasmas + commits perdidos).
3. **`files_ignore: version.sbt`** — defensa en profundidad. Aunque ahora el diff va contra el tag, mantener la exclusión protege contra cualquier escenario futuro donde `version.sbt` aparezca en el diff sin representar contenido real.

Si el repo no tiene tags todavía (caso `v0.x` inicial), cae a comparar contra el commit raíz — primer release siempre se dispara.

## Alcance

Este reusable lo usan **todos los libs Scala BQN** que invocan `BQN-UY/CI-CD/.github/workflows/scala-make-release-lib.yml@main`. Probablemente la mayoría tuvieron releases fantasmas similares — auditoría rápida de los `release` recientes de cada lib se hace post-merge.

Solo `scala-make-release-lib.yml` tiene este patrón de gate (verificado: `grep -l "tj-actions/changed-files"` en `.github/workflows/`). `scala-make-release-jar.yml` y `scala-make-release-web.yml` no tienen el mismo flujo.

## Validación post-merge

- Trigger manual de `make-release` en bol-protocol (`workflow_dispatch`, `force-release: false`) sin cambios → debería **no publicar**.
- En el siguiente cron natural, idem: si no hay cambios desde v3.33.0, no publica v3.34.0.

## Origen del hallazgo

Santi flageó el patrón de "releases fantasmas" durante la cobertura de tracking organizacional (rama `pendientes-pablo-santi`, item bol-protocol). Pablo solicitó arreglar en lugar de deshabilitar, ya que el gate originalmente estaba pensado para hacer release-on-change.