### PR TITLE
fix(scala-api-publish): forzar decimal en contador NNN (octal bug en NN ≥ 008)

### DIFF
--- a/.github/workflows/scala-api-publish.yml
+++ b/.github/workflows/scala-api-publish.yml
@@ -91,11 +91,13 @@ jobs:
             exit 1
           fi
 
-          # Calcular próximo NNN
+          # Calcular próximo NNN.
+          # `10#` fuerza interpretación decimal — sin él, valores con leading zero
+          # (ej. "008") se interpretan como octal y `8`/`9` rompen la aritmética.
           LAST_N=$(git tag --list "${PREFIX}.*" \
                     | sed -n "s|^${PREFIX}\.\([0-9]\+\)\$|\1|p" \
                     | sort -n | tail -1 || true)
-          NEXT=$(( ${LAST_N:-0} + 1 ))
+          NEXT=$(( 10#${LAST_N:-0} + 1 ))
           NNN=$(printf "%03d" "$NEXT")
           TAG="${PREFIX}.${NNN}"
 


### PR DESCRIPTION
## Summary

`NEXT=\$(( \${LAST_N:-0} + 1 ))` en `scala-api-publish.yml` interpretaba `LAST_N` como octal cuando tenía leading zero. Bash falla con `value too great for base (error token is "008")` para `LAST_N=008` o `009`.

## Síntoma

```
line 48: 008: value too great for base (error token is "008")
line 49: NEXT: unbound variable
##[error]Process completed with exit code 1.
```

## Caso histórico

En `BQN-UY/acp-api`, los snapshots posteriores a `v1.1.0-snapshot.008` fallaron silenciosamente:

- PR BQN-UY/acp-api#29 merge → debió crear `.009` → ❌
- PR BQN-UY/acp-api#30 merge → debió crear `.010` → ❌
- PR BQN-UY/acp-api#31 merge → debió crear `.011` → ❌

Sin snapshot tag → no GitHub pre-release → no deploy automático a testing. La rama `release/v1.1.0` (creada por `start-release` el 2026-05-04) tampoco va a publicar `v1.1.0-rc.001` correctamente sin este fix (el contador rc arrancaría desde 0+1=1, OK, pero al llegar a 008 fallará igual).

## Fix

Prefijar `10#` a la expansión del contador:

```diff
-          NEXT=$(( ${LAST_N:-0} + 1 ))
+          NEXT=$(( 10#${LAST_N:-0} + 1 ))
```

Patrón estándar en bash para contadores con padding (`printf "%03d"`).

## Impacto

- **Aplica retroactivamente** desde la próxima ejecución del workflow.
- **No requiere republicar** los snapshots faltantes — los artefactos finales se generan en `make-release`.
- Para que `release/v1.1.0` (o cualquier branch nueva) reciba su rc tag, basta con un commit nuevo o re-correr el workflow.

## Test plan

- [x] Diff revisado — cambio mínimo, scope acotado.
- [ ] Tras merge: validar que el próximo push a `develop` o `release/**` en cualquier API genera el tag esperado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)